### PR TITLE
Fetch live week of OANDA candles

### DIFF
--- a/src/trading/quantum_pair_trainer.hpp
+++ b/src/trading/quantum_pair_trainer.hpp
@@ -120,7 +120,7 @@ private:
     
     // Data preparation
     std::vector<sep::connectors::MarketData> fetchTrainingData(
-        const std::string& pair_symbol, size_t hours_back);
+        const std::string& pair_symbol);
     std::vector<uint8_t> convertToBitstream(
         const std::vector<sep::connectors::MarketData>& market_data);
     

--- a/src/training/training_coordinator.cpp
+++ b/src/training/training_coordinator.cpp
@@ -154,7 +154,7 @@ TrainingResult TrainingCoordinator::executeCudaTraining(const std::string& pair,
         sep::trading::QuantumPairTrainer trainer(config);
         
         // Fetch real OANDA market data for training
-        auto market_data = trainer.fetchTrainingData(pair, 24); // 24 hours of real data
+        auto market_data = trainer.fetchTrainingData(pair); // previous week of real data
         
         if (!market_data.empty()) {
             // Convert market data to training format

--- a/tests/data_pipeline/test_data_integrity.cpp
+++ b/tests/data_pipeline/test_data_integrity.cpp
@@ -32,7 +32,7 @@ TEST_F(DataIntegrityTest, QuantumPairTrainerUsesRealOandaData) {
         // This should attempt to fetch real OANDA data and fail with auth error
         // (proving it's not using simulated data)
         EXPECT_THROW(
-            trainer.fetchTrainingData("EUR_USD", 1),
+            trainer.fetchTrainingData("EUR_USD"),
             std::runtime_error
         );
         
@@ -110,7 +110,7 @@ TEST_F(DataIntegrityTest, NoHardcodedSimulationValues) {
     
     // Without credentials, should throw, not return simulated data with 1.0850
     EXPECT_THROW(
-        trainer.fetchTrainingData("EUR_USD", 1),
+        trainer.fetchTrainingData("EUR_USD"),
         std::runtime_error
     );
 }


### PR DESCRIPTION
## Summary
- fetch one week of OANDA M1 candles for a pair and surface API errors
- update trainer and coordinator to use live candle data only
- adjust data integrity tests for new fetch API

## Testing
- `./build.sh --no-docker` *(fails: Configuring incomplete, errors occurred; ninja: error: loading 'build.ninja')*

------
https://chatgpt.com/codex/tasks/task_e_689980e3f28c832ab7bcc50dfe3edacd