### PR TITLE
Add full pipeline integration test and caching support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ Thumbs.db
 # output/
 logs/
 *.txt
+!tests/CMakeLists.txt
 
 # Dependencies
 node_modules/

--- a/src/trading/quantum_pair_trainer.cpp
+++ b/src/trading/quantum_pair_trainer.cpp
@@ -1,392 +1,450 @@
 
-#include "common/sep_precompiled.h"
 #include "quantum_pair_trainer.hpp"
+
+#include <iomanip>
+#include <sstream>
 #include <stdexcept>
 #include <thread>
-#include <sstream>
-#include <iomanip>
 
-namespace sep::trading {
+#include "common/sep_precompiled.h"
 
-QuantumPairTrainer::QuantumPairTrainer(const QuantumTrainingConfig& config) 
-    : config_(config) {
-    
-    // Initialize quantum components
-    sep::quantum::QFHOptions qfh_options;
-    qfh_options.collapse_threshold = 0.3f;
-    qfh_options.flip_threshold = 0.7f;
-    qfh_processor_ = std::make_unique<sep::quantum::QFHBasedProcessor>(qfh_options);
-    
-    // Initialize manifold optimizer
-    sep::quantum::manifold::QuantumManifoldOptimizer::Config manifold_config;
-    manifold_optimizer_ = std::make_unique<sep::quantum::manifold::QuantumManifoldOptimizer>(manifold_config);
-    
-    // Initialize pattern evolution bridge
-    sep::quantum::PatternEvolutionBridge::Config evo_config;
-    pattern_evolver_ = std::make_unique<sep::quantum::PatternEvolutionBridge>(evo_config);
-    
-    // Initialize engine facade (singleton)
-    engine_facade_ = &sep::engine::EngineFacade::getInstance();
-    if (engine_facade_->initialize() != sep::core::Result::SUCCESS) {
-        throw std::runtime_error("Failed to initialize engine facade");
-    }
-    
-    // Initialize OANDA connector with real credentials
-    const char* api_key = std::getenv("OANDA_API_KEY");
-    const char* account_id = std::getenv("OANDA_ACCOUNT_ID");
-    if (api_key && account_id) {
-        oanda_connector_ = std::make_unique<sep::connectors::OandaConnector>(api_key, account_id, true); // true = sandbox
-        if (!oanda_connector_->initialize()) {
-            throw std::runtime_error("Failed to initialize OANDA connector: " + oanda_connector_->getLastError());
+namespace sep::trading
+{
+
+    QuantumPairTrainer::QuantumPairTrainer(const QuantumTrainingConfig& config) : config_(config)
+    {
+        // Initialize quantum components
+        sep::quantum::QFHOptions qfh_options;
+        qfh_options.collapse_threshold = 0.3f;
+        qfh_options.flip_threshold = 0.7f;
+        qfh_processor_ = std::make_unique<sep::quantum::QFHBasedProcessor>(qfh_options);
+
+        // Initialize manifold optimizer
+        sep::quantum::manifold::QuantumManifoldOptimizer::Config manifold_config;
+        manifold_optimizer_ =
+            std::make_unique<sep::quantum::manifold::QuantumManifoldOptimizer>(manifold_config);
+
+        // Initialize pattern evolution bridge
+        sep::quantum::PatternEvolutionBridge::Config evo_config;
+        pattern_evolver_ = std::make_unique<sep::quantum::PatternEvolutionBridge>(evo_config);
+
+        // Initialize engine facade (singleton)
+        engine_facade_ = &sep::engine::EngineFacade::getInstance();
+        if (engine_facade_->initialize() != sep::core::Result::SUCCESS)
+        {
+            throw std::runtime_error("Failed to initialize engine facade");
         }
-    } else {
-        // Log warning but continue - allows unit testing without credentials
-        std::cerr << "Warning: OANDA credentials not found. Set OANDA_API_KEY and OANDA_ACCOUNT_ID environment variables for real data." << std::endl;
-    }
-}
 
-QuantumPairTrainer::~QuantumPairTrainer() {
-    if (training_active_.load()) {
-        cancelTraining();
-    }
-    
-    // Note: engine_facade_ is a singleton, don't shutdown here
-}
-
-std::future<PairTrainingResult> QuantumPairTrainer::trainPairAsync(const std::string& pair_symbol) {
-    return std::async(std::launch::async, [this, pair_symbol]() {
-        return trainPair(pair_symbol);
-    });
-}
-
-PairTrainingResult QuantumPairTrainer::trainPair(const std::string& pair_symbol) {
-    std::lock_guard<std::mutex> lock(results_mutex_);
-    
-    PairTrainingResult result;
-    result.pair_symbol = pair_symbol;
-    result.training_start = std::chrono::system_clock::now();
-    
-    training_active_.store(true);
-    total_training_sessions_++;
-    
-    try {
-        // Perform quantum training
-        result = performQuantumTraining(pair_symbol);
-        
-        if (result.training_successful) {
-            successful_training_sessions_++;
+        // Initialize OANDA connector with real credentials
+        const char* api_key = std::getenv("OANDA_API_KEY");
+        const char* account_id = std::getenv("OANDA_ACCOUNT_ID");
+        if (api_key && account_id)
+        {
+            oanda_connector_ = std::make_unique<sep::connectors::OandaConnector>(
+                api_key, account_id, true);  // true = sandbox
+            if (!oanda_connector_->initialize())
+            {
+                throw std::runtime_error("Failed to initialize OANDA connector: " +
+                                         oanda_connector_->getLastError());
+            }
         }
-        
-        // Store result in history
-        training_history_[pair_symbol].push_back(result);
-        
-        // Save to persistence
-        saveTrainingResult(result);
-        
-    } catch (const std::exception& e) {
-        result.training_successful = false;
-        result.error_message = e.what();
-        result.failure_reason = "Exception during training";
-    }
-    
-    result.training_end = std::chrono::system_clock::now();
-    training_active_.store(false);
-    
-    return result;
-}
-
-std::future<std::vector<PairTrainingResult>> QuantumPairTrainer::trainMultiplePairsAsync(
-    const std::vector<std::string>& pair_symbols) {
-    
-    return std::async(std::launch::async, [this, pair_symbols]() {
-        return trainMultiplePairs(pair_symbols);
-    });
-}
-
-std::vector<PairTrainingResult> QuantumPairTrainer::trainMultiplePairs(
-    const std::vector<std::string>& pair_symbols) {
-    
-    std::vector<std::future<PairTrainingResult>> futures;
-    
-    // Launch parallel training tasks
-    for (const auto& pair : pair_symbols) {
-        futures.push_back(trainPairAsync(pair));
-    }
-    
-    // Collect results
-    std::vector<PairTrainingResult> results;
-    for (auto& future : futures) {
-        results.push_back(future.get());
-    }
-    
-    return results;
-}
-
-void QuantumPairTrainer::cancelTraining() {
-    cancellation_requested_.store(true);
-    training_active_.store(false);
-}
-
-void QuantumPairTrainer::pauseTraining() {
-    training_paused_.store(true);
-}
-
-void QuantumPairTrainer::resumeTraining() {
-    training_paused_.store(false);
-}
-
-void QuantumPairTrainer::updateConfig(const QuantumTrainingConfig& config) {
-    std::lock_guard<std::mutex> lock(config_mutex_);
-    config_ = config;
-}
-
-QuantumTrainingConfig QuantumPairTrainer::getCurrentConfig() const {
-    std::lock_guard<std::mutex> lock(config_mutex_);
-    return config_;
-}
-
-std::vector<PairTrainingResult> QuantumPairTrainer::getTrainingHistory() const {
-    std::lock_guard<std::mutex> lock(results_mutex_);
-    
-    std::vector<PairTrainingResult> all_results;
-    for (const auto& [pair, results] : training_history_) {
-        all_results.insert(all_results.end(), results.begin(), results.end());
-    }
-    
-    return all_results;
-}
-
-PairTrainingResult QuantumPairTrainer::getLastTrainingResult(const std::string& pair_symbol) const {
-    std::lock_guard<std::mutex> lock(results_mutex_);
-    
-    auto it = training_history_.find(pair_symbol);
-    if (it != training_history_.end() && !it->second.empty()) {
-        return it->second.back();
-    }
-    
-    // Return empty result if no training history found
-    PairTrainingResult empty_result;
-    empty_result.pair_symbol = pair_symbol;
-    empty_result.training_successful = false;
-    empty_result.error_message = "No training history found";
-    return empty_result;
-}
-
-PairTrainingResult QuantumPairTrainer::performQuantumTraining(const std::string& pair_symbol) {
-    PairTrainingResult result;
-    result.pair_symbol = pair_symbol;
-    result.training_start = std::chrono::system_clock::now();
-    
-    try {
-        // Step 1: Fetch training data
-        auto training_data = fetchTrainingData(pair_symbol, config_.training_window_hours);
-        result.training_samples_processed = training_data.size();
-        
-        if (training_data.size() < 100) {
-            throw std::runtime_error("Insufficient training data");
+        else
+        {
+            // Log warning but continue - allows unit testing without credentials
+            std::cerr << "Warning: OANDA credentials not found. Set OANDA_API_KEY and "
+                         "OANDA_ACCOUNT_ID environment variables for real data."
+                      << std::endl;
         }
-        
-        // Step 2: Convert to bitstream for quantum analysis
-        auto bitstream = convertToBitstream(training_data);
-        
-        // Step 3: Perform quantum field harmonics analysis
-        auto qfh_result = performQFHAnalysis(bitstream);
-        
-        // Step 4: Discover patterns
-        auto patterns = discoverPatterns(training_data);
-        result.discovered_patterns = patterns;
-        
-        // Step 5: Optimize parameters
-        auto optimized_config = optimizeParameters(pair_symbol, training_data);
-        result.optimized_config = optimized_config;
-        
-        // Step 6: Calculate performance metrics
-        result.overall_accuracy = calculateAccuracy(training_data, optimized_config);
-        result.high_confidence_accuracy = result.overall_accuracy * 1.2; // Simulated high-confidence boost
-        result.signal_rate = 0.19; // Simulated 19% signal rate from breakthrough
-        result.profitability_score = calculateProfitabilityScore(
-            result.high_confidence_accuracy, result.signal_rate);
-        
-        // Step 7: Validate results
-        if (result.high_confidence_accuracy >= 0.60 && result.profitability_score >= 150.0) {
-            result.training_successful = true;
-        } else {
+    }
+
+    QuantumPairTrainer::~QuantumPairTrainer()
+    {
+        if (training_active_.load())
+        {
+            cancelTraining();
+        }
+
+        // Note: engine_facade_ is a singleton, don't shutdown here
+    }
+
+    std::future<PairTrainingResult> QuantumPairTrainer::trainPairAsync(
+        const std::string& pair_symbol)
+    {
+        return std::async(std::launch::async,
+                          [this, pair_symbol]() { return trainPair(pair_symbol); });
+    }
+
+    PairTrainingResult QuantumPairTrainer::trainPair(const std::string& pair_symbol)
+    {
+        std::lock_guard<std::mutex> lock(results_mutex_);
+
+        PairTrainingResult result;
+        result.pair_symbol = pair_symbol;
+        result.training_start = std::chrono::system_clock::now();
+
+        training_active_.store(true);
+        total_training_sessions_++;
+
+        try
+        {
+            // Perform quantum training
+            result = performQuantumTraining(pair_symbol);
+
+            if (result.training_successful)
+            {
+                successful_training_sessions_++;
+            }
+
+            // Store result in history
+            training_history_[pair_symbol].push_back(result);
+
+            // Save to persistence
+            saveTrainingResult(result);
+        }
+        catch (const std::exception& e)
+        {
             result.training_successful = false;
-            result.failure_reason = "Performance thresholds not met";
+            result.error_message = e.what();
+            result.failure_reason = "Exception during training";
         }
-        
-        result.convergence_iterations = 500; // Simulated convergence
-        
-    } catch (const std::exception& e) {
-        result.training_successful = false;
-        result.error_message = e.what();
-        result.failure_reason = "Training execution failed";
-    }
-    
-    result.training_end = std::chrono::system_clock::now();
-    return result;
-}
 
-std::vector<sep::connectors::MarketData> QuantumPairTrainer::fetchTrainingData(
-    const std::string& pair_symbol, size_t hours_back) {
-    
-    if (!oanda_connector_) {
-        throw std::runtime_error("OANDA connector not initialized. Check your OANDA_API_KEY and OANDA_ACCOUNT_ID environment variables.");
+        result.training_end = std::chrono::system_clock::now();
+        training_active_.store(false);
+
+        return result;
     }
-    
-    // Calculate timestamps for the requested time range
-    auto now = std::chrono::system_clock::now();
-    auto start_time = now - std::chrono::hours(hours_back);
-    
-    // Format timestamps into ISO 8601 strings required by OANDA API
-    auto formatTimestamp = [](const std::chrono::system_clock::time_point& tp) -> std::string {
-        auto time_t = std::chrono::system_clock::to_time_t(tp);
+
+    std::future<std::vector<PairTrainingResult>> QuantumPairTrainer::trainMultiplePairsAsync(
+        const std::vector<std::string>& pair_symbols)
+    {
+        return std::async(std::launch::async,
+                          [this, pair_symbols]() { return trainMultiplePairs(pair_symbols); });
+    }
+
+    std::vector<PairTrainingResult> QuantumPairTrainer::trainMultiplePairs(
+        const std::vector<std::string>& pair_symbols)
+    {
+        std::vector<std::future<PairTrainingResult>> futures;
+
+        // Launch parallel training tasks
+        for (const auto& pair : pair_symbols)
+        {
+            futures.push_back(trainPairAsync(pair));
+        }
+
+        // Collect results
+        std::vector<PairTrainingResult> results;
+        for (auto& future : futures)
+        {
+            results.push_back(future.get());
+        }
+
+        return results;
+    }
+
+    void QuantumPairTrainer::cancelTraining()
+    {
+        cancellation_requested_.store(true);
+        training_active_.store(false);
+    }
+
+    void QuantumPairTrainer::pauseTraining() { training_paused_.store(true); }
+
+    void QuantumPairTrainer::resumeTraining() { training_paused_.store(false); }
+
+    void QuantumPairTrainer::updateConfig(const QuantumTrainingConfig& config)
+    {
+        std::lock_guard<std::mutex> lock(config_mutex_);
+        config_ = config;
+    }
+
+    QuantumTrainingConfig QuantumPairTrainer::getCurrentConfig() const
+    {
+        std::lock_guard<std::mutex> lock(config_mutex_);
+        return config_;
+    }
+
+    std::vector<PairTrainingResult> QuantumPairTrainer::getTrainingHistory() const
+    {
+        std::lock_guard<std::mutex> lock(results_mutex_);
+
+        std::vector<PairTrainingResult> all_results;
+        for (const auto& [pair, results] : training_history_)
+        {
+            all_results.insert(all_results.end(), results.begin(), results.end());
+        }
+
+        return all_results;
+    }
+
+    PairTrainingResult QuantumPairTrainer::getLastTrainingResult(
+        const std::string& pair_symbol) const
+    {
+        std::lock_guard<std::mutex> lock(results_mutex_);
+
+        auto it = training_history_.find(pair_symbol);
+        if (it != training_history_.end() && !it->second.empty())
+        {
+            return it->second.back();
+        }
+
+        // Return empty result if no training history found
+        PairTrainingResult empty_result;
+        empty_result.pair_symbol = pair_symbol;
+        empty_result.training_successful = false;
+        empty_result.error_message = "No training history found";
+        return empty_result;
+    }
+
+    PairTrainingResult QuantumPairTrainer::performQuantumTraining(const std::string& pair_symbol)
+    {
+        PairTrainingResult result;
+        result.pair_symbol = pair_symbol;
+        result.training_start = std::chrono::system_clock::now();
+
+        try
+        {
+            // Step 1: Fetch training data
+            auto training_data = fetchTrainingData(pair_symbol, config_.training_window_hours);
+            result.training_samples_processed = training_data.size();
+
+            if (training_data.size() < 100)
+            {
+                throw std::runtime_error("Insufficient training data");
+            }
+
+            // Step 2: Convert to bitstream for quantum analysis
+            auto bitstream = convertToBitstream(training_data);
+
+            // Step 3: Perform quantum field harmonics analysis
+            auto qfh_result = performQFHAnalysis(bitstream);
+
+            // Step 4: Discover patterns
+            auto patterns = discoverPatterns(training_data);
+            result.discovered_patterns = patterns;
+
+            // Step 5: Optimize parameters
+            auto optimized_config = optimizeParameters(pair_symbol, training_data);
+            result.optimized_config = optimized_config;
+
+            // Step 6: Calculate performance metrics
+            result.overall_accuracy = calculateAccuracy(training_data, optimized_config);
+            result.high_confidence_accuracy =
+                result.overall_accuracy * 1.2;  // Simulated high-confidence boost
+            result.signal_rate = 0.19;          // Simulated 19% signal rate from breakthrough
+            result.profitability_score =
+                calculateProfitabilityScore(result.high_confidence_accuracy, result.signal_rate);
+
+            // Step 7: Validate results
+            if (result.high_confidence_accuracy >= 0.60 && result.profitability_score >= 150.0)
+            {
+                result.training_successful = true;
+            }
+            else
+            {
+                result.training_successful = false;
+                result.failure_reason = "Performance thresholds not met";
+            }
+
+            result.convergence_iterations = 500;  // Simulated convergence
+        }
+        catch (const std::exception& e)
+        {
+            result.training_successful = false;
+            result.error_message = e.what();
+            result.failure_reason = "Training execution failed";
+        }
+
+        result.training_end = std::chrono::system_clock::now();
+        return result;
+    }
+
+    std::vector<sep::connectors::MarketData> QuantumPairTrainer::fetchTrainingData(
+        const std::string& pair_symbol, size_t hours_back)
+    {
+        if (!oanda_connector_)
+        {
+            throw std::runtime_error(
+                "OANDA connector not initialized. Check your OANDA_API_KEY and OANDA_ACCOUNT_ID "
+                "environment variables.");
+        }
+
+        // Calculate timestamps for the requested time range
+        auto now = std::chrono::system_clock::now();
+        auto start_time = now - std::chrono::hours(hours_back);
+
+        // Format timestamps into ISO 8601 strings required by OANDA API
+        auto formatTimestamp = [](const std::chrono::system_clock::time_point& tp) -> std::string {
+            auto time_t = std::chrono::system_clock::to_time_t(tp);
+            std::stringstream ss;
+            ss << std::put_time(std::gmtime(&time_t), "%Y-%m-%dT%H:%M:%SZ");
+            return ss.str();
+        };
+
+        std::string from_str = formatTimestamp(start_time);
+        std::string to_str = formatTimestamp(now);
+
+        // Fetch real OANDA data
+        auto oanda_candles =
+            oanda_connector_->getHistoricalData(pair_symbol, "M1", from_str, to_str);
+
+        // If no data returned (e.g., when running offline), fall back to any
+        // locally cached generic data without time range parameters
+        if (oanda_candles.empty())
+        {
+            oanda_candles = oanda_connector_->getHistoricalData(pair_symbol, "M1", "", "");
+        }
+
+        if (oanda_candles.empty())
+        {
+            throw std::runtime_error("Failed to fetch OANDA data: " +
+                                     oanda_connector_->getLastError());
+        }
+
+        // Convert OandaCandle to MarketData format
+        std::vector<sep::connectors::MarketData> market_data;
+        market_data.reserve(oanda_candles.size());
+
+        for (const auto& candle : oanda_candles)
+        {
+            sep::connectors::MarketData md;
+            md.instrument = pair_symbol;
+            md.timestamp = std::chrono::duration_cast<std::chrono::milliseconds>(
+                               sep::common::parseTimestamp(candle.time).time_since_epoch())
+                               .count();
+            md.mid = candle.close;
+            md.bid = candle.low;   // Approximation - could be improved with tick data
+            md.ask = candle.high;  // Approximation - could be improved with tick data
+            md.volume = candle.volume;
+            md.atr = 0.0050;  // Will be calculated later from historical volatility
+
+            market_data.push_back(md);
+        }
+
+        return market_data;
+    }
+
+    std::vector<uint8_t> QuantumPairTrainer::convertToBitstream(
+        const std::vector<sep::connectors::MarketData>& market_data)
+    {
+        std::vector<uint8_t> bitstream;
+
+        if (market_data.size() < 2) return bitstream;
+
+        // Convert price movements to bits
+        for (size_t i = 1; i < market_data.size(); ++i)
+        {
+            double price_change = market_data[i].mid - market_data[i - 1].mid;
+            bitstream.push_back(price_change >= 0 ? 1 : 0);
+        }
+
+        return bitstream;
+    }
+
+    sep::quantum::QFHResult QuantumPairTrainer::performQFHAnalysis(
+        const std::vector<uint8_t>& bitstream)
+    {
+        if (!qfh_processor_)
+        {
+            throw std::runtime_error("QFH processor not initialized");
+        }
+
+        return qfh_processor_->analyze(bitstream);
+    }
+
+    std::vector<sep::quantum::Pattern> QuantumPairTrainer::discoverPatterns(
+        const std::vector<sep::connectors::MarketData>& market_data)
+    {
+        std::vector<sep::quantum::Pattern> patterns;
+
+        // Create sample patterns based on market data analysis
+        sep::quantum::Pattern trend_pattern;
+        trend_pattern.id = "trend_" + std::to_string(std::rand());
+        trend_pattern.timestamp = std::chrono::duration_cast<std::chrono::milliseconds>(
+                                      std::chrono::system_clock::now().time_since_epoch())
+                                      .count();
+        trend_pattern.quantum_state.coherence = 0.75f;
+        trend_pattern.quantum_state.stability = 0.65f;
+
+        patterns.push_back(trend_pattern);
+
+        return patterns;
+    }
+
+    QuantumTrainingConfig QuantumPairTrainer::optimizeParameters(
+        const std::string& pair_symbol,
+        const std::vector<sep::connectors::MarketData>& training_data)
+    {
+        // Return optimized configuration based on breakthrough parameters
+        QuantumTrainingConfig optimized = config_;
+
+        // Use optimal weights from breakthrough analysis
+        optimized.stability_weight = 0.4;
+        optimized.coherence_weight = 0.1;
+        optimized.entropy_weight = 0.5;
+        optimized.confidence_threshold = 0.65;
+        optimized.coherence_threshold = 0.30;
+
+        return optimized;
+    }
+
+    double QuantumPairTrainer::calculateAccuracy(
+        const std::vector<sep::connectors::MarketData>& data, const QuantumTrainingConfig& config)
+    {
+        // Simulate accuracy calculation based on quantum analysis
+        // In real implementation, this would backtest the configuration
+
+        double base_accuracy = 0.58;  // Base accuracy
+
+        // Bonus for optimal configuration
+        if (std::abs(config.stability_weight - 0.4) < 0.1 &&
+            std::abs(config.coherence_weight - 0.1) < 0.05 &&
+            std::abs(config.entropy_weight - 0.5) < 0.1)
+        {
+            base_accuracy += 0.05;  // 5% bonus for optimal config
+        }
+
+        return base_accuracy;
+    }
+
+    double QuantumPairTrainer::calculateProfitabilityScore(double accuracy, double signal_rate)
+    {
+        // Profitability Score = (High-Conf Accuracy - 50) × Signal Rate × 100
+        return (accuracy - 0.50) * signal_rate * 1000.0;
+    }
+
+    void QuantumPairTrainer::saveTrainingResult(const PairTrainingResult& result)
+    {
+        // In real implementation, this would save to database or file
+        // For now, just store in memory
+    }
+
+    PairTrainingResult QuantumPairTrainer::loadTrainingResult(const std::string& pair_symbol)
+    {
+        // In real implementation, this would load from persistence
+        return getLastTrainingResult(pair_symbol);
+    }
+
+    std::string QuantumPairTrainer::getCacheKey(const std::string& pair_symbol) const
+    {
+        auto now = std::chrono::system_clock::now();
+        auto time_t = std::chrono::system_clock::to_time_t(now);
         std::stringstream ss;
-        ss << std::put_time(std::gmtime(&time_t), "%Y-%m-%dT%H:%M:%SZ");
+        ss << pair_symbol << "_" << std::put_time(std::localtime(&time_t), "%Y%m%d");
         return ss.str();
-    };
-    
-    std::string from_str = formatTimestamp(start_time);
-    std::string to_str = formatTimestamp(now);
-    
-    // Fetch real OANDA data
-    auto oanda_candles = oanda_connector_->getHistoricalData(pair_symbol, "M1", from_str, to_str);
-    
-    if (oanda_candles.empty()) {
-        throw std::runtime_error("Failed to fetch OANDA data: " + oanda_connector_->getLastError());
     }
-    
-    // Convert OandaCandle to MarketData format
-    std::vector<sep::connectors::MarketData> market_data;
-    market_data.reserve(oanda_candles.size());
-    
-    for (const auto& candle : oanda_candles) {
-        sep::connectors::MarketData md;
-        md.instrument = pair_symbol;
-        md.timestamp = std::chrono::duration_cast<std::chrono::milliseconds>(
-            sep::common::parseTimestamp(candle.time).time_since_epoch()).count();
-        md.mid = candle.close;
-        md.bid = candle.low;   // Approximation - could be improved with tick data
-        md.ask = candle.high;  // Approximation - could be improved with tick data
-        md.volume = candle.volume;
-        md.atr = 0.0050; // Will be calculated later from historical volatility
-        
-        market_data.push_back(md);
+
+    bool QuantumPairTrainer::isCacheValid(const std::string& cache_key) const
+    {
+        std::lock_guard<std::mutex> lock(cache_mutex_);
+        return result_cache_.find(cache_key) != result_cache_.end();
     }
-    
-    return market_data;
-}
 
-std::vector<uint8_t> QuantumPairTrainer::convertToBitstream(
-    const std::vector<sep::connectors::MarketData>& market_data) {
-    
-    std::vector<uint8_t> bitstream;
-    
-    if (market_data.size() < 2) return bitstream;
-    
-    // Convert price movements to bits
-    for (size_t i = 1; i < market_data.size(); ++i) {
-        double price_change = market_data[i].mid - market_data[i-1].mid;
-        bitstream.push_back(price_change >= 0 ? 1 : 0);
+    void QuantumPairTrainer::updateCache(const std::string& cache_key,
+                                         const PairTrainingResult& result)
+    {
+        std::lock_guard<std::mutex> lock(cache_mutex_);
+        result_cache_[cache_key] = result;
     }
-    
-    return bitstream;
-}
 
-sep::quantum::QFHResult QuantumPairTrainer::performQFHAnalysis(
-    const std::vector<uint8_t>& bitstream) {
-    
-    if (!qfh_processor_) {
-        throw std::runtime_error("QFH processor not initialized");
-    }
-    
-    return qfh_processor_->analyze(bitstream);
-}
-
-std::vector<sep::quantum::Pattern> QuantumPairTrainer::discoverPatterns(
-    const std::vector<sep::connectors::MarketData>& market_data) {
-    
-    std::vector<sep::quantum::Pattern> patterns;
-    
-    // Create sample patterns based on market data analysis
-    sep::quantum::Pattern trend_pattern;
-    trend_pattern.id = "trend_" + std::to_string(std::rand());
-    trend_pattern.timestamp = std::chrono::duration_cast<std::chrono::milliseconds>(
-        std::chrono::system_clock::now().time_since_epoch()).count();
-    trend_pattern.quantum_state.coherence = 0.75f;
-    trend_pattern.quantum_state.stability = 0.65f;
-    
-    patterns.push_back(trend_pattern);
-    
-    return patterns;
-}
-
-QuantumTrainingConfig QuantumPairTrainer::optimizeParameters(
-    const std::string& pair_symbol,
-    const std::vector<sep::connectors::MarketData>& training_data) {
-    
-    // Return optimized configuration based on breakthrough parameters
-    QuantumTrainingConfig optimized = config_;
-    
-    // Use optimal weights from breakthrough analysis
-    optimized.stability_weight = 0.4;
-    optimized.coherence_weight = 0.1;
-    optimized.entropy_weight = 0.5;
-    optimized.confidence_threshold = 0.65;
-    optimized.coherence_threshold = 0.30;
-    
-    return optimized;
-}
-
-double QuantumPairTrainer::calculateAccuracy(
-    const std::vector<sep::connectors::MarketData>& data,
-    const QuantumTrainingConfig& config) {
-    
-    // Simulate accuracy calculation based on quantum analysis
-    // In real implementation, this would backtest the configuration
-    
-    double base_accuracy = 0.58; // Base accuracy
-    
-    // Bonus for optimal configuration
-    if (std::abs(config.stability_weight - 0.4) < 0.1 &&
-        std::abs(config.coherence_weight - 0.1) < 0.05 &&
-        std::abs(config.entropy_weight - 0.5) < 0.1) {
-        base_accuracy += 0.05; // 5% bonus for optimal config
-    }
-    
-    return base_accuracy;
-}
-
-double QuantumPairTrainer::calculateProfitabilityScore(double accuracy, double signal_rate) {
-    // Profitability Score = (High-Conf Accuracy - 50) × Signal Rate × 100
-    return (accuracy - 0.50) * signal_rate * 1000.0;
-}
-
-void QuantumPairTrainer::saveTrainingResult(const PairTrainingResult& result) {
-    // In real implementation, this would save to database or file
-    // For now, just store in memory
-}
-
-PairTrainingResult QuantumPairTrainer::loadTrainingResult(const std::string& pair_symbol) {
-    // In real implementation, this would load from persistence
-    return getLastTrainingResult(pair_symbol);
-}
-
-std::string QuantumPairTrainer::getCacheKey(const std::string& pair_symbol) const {
-    auto now = std::chrono::system_clock::now();
-    auto time_t = std::chrono::system_clock::to_time_t(now);
-    std::stringstream ss;
-    ss << pair_symbol << "_" << std::put_time(std::localtime(&time_t), "%Y%m%d");
-    return ss.str();
-}
-
-bool QuantumPairTrainer::isCacheValid(const std::string& cache_key) const {
-    // Simple cache validation - in real implementation would check timestamps
-    return false;
-}
-
-void QuantumPairTrainer::updateCache(const std::string& cache_key, const PairTrainingResult& result) {
-    // Cache management implementation
-}
-
-} // namespace sep::trading
+}  // namespace sep::trading

--- a/src/trading/quantum_pair_trainer.hpp
+++ b/src/trading/quantum_pair_trainer.hpp
@@ -7,182 +7,191 @@
 #include "quantum/pattern_evolution_bridge.h"
 #include "quantum/quantum_manifold_optimizer.h"
 
-namespace sep::trading {
+namespace sep::trading
+{
 
-/**
- * Quantum Training Configuration for Currency Pairs
- * Based on 60.73% accuracy breakthrough parameters
- */
-struct QuantumTrainingConfig {
-    // Optimal weights from breakthrough analysis
-    double stability_weight = 0.4;    // 40% weight with inversion logic
-    double coherence_weight = 0.1;    // 10% minimal influence  
-    double entropy_weight = 0.5;      // 50% primary signal driver
-    
-    // Optimal thresholds from systematic optimization
-    double confidence_threshold = 0.65;  // High-confidence threshold
-    double coherence_threshold = 0.30;   // Coherence threshold
-    
-    // Training parameters
-    size_t training_window_hours = 120;   // 5 days of M1 data
-    size_t pattern_analysis_depth = 50;   // Forward window size
-    size_t max_training_iterations = 1000;
-    double convergence_tolerance = 1e-6;
-    
-    // Multi-timeframe analysis
-    bool enable_m5_analysis = true;
-    bool enable_m15_analysis = true;
-    bool require_triple_confirmation = true;
-    
-    // CUDA optimization
-    bool enable_cuda_acceleration = true;
-    size_t cuda_batch_size = 256;
-    size_t cuda_threads_per_block = 512;
-};
+    /**
+     * Quantum Training Configuration for Currency Pairs
+     * Based on 60.73% accuracy breakthrough parameters
+     */
+    struct QuantumTrainingConfig
+    {
+        // Optimal weights from breakthrough analysis
+        double stability_weight = 0.4;  // 40% weight with inversion logic
+        double coherence_weight = 0.1;  // 10% minimal influence
+        double entropy_weight = 0.5;    // 50% primary signal driver
 
-/**
- * Training Results for a Currency Pair
- */
-struct PairTrainingResult {
-    std::string pair_symbol;
-    bool training_successful = false;
-    
-    // Performance metrics
-    double overall_accuracy = 0.0;
-    double high_confidence_accuracy = 0.0;
-    double signal_rate = 0.0;
-    double profitability_score = 0.0;  // (High-Conf Accuracy - 50) × Signal Rate
-    
-    // Optimized parameters
-    sep::trading::QuantumTrainingConfig optimized_config;
-    
-    // Training metadata
-    std::chrono::system_clock::time_point training_start;
-    std::chrono::system_clock::time_point training_end;
-    size_t training_samples_processed = 0;
-    size_t convergence_iterations = 0;
-    
-    // Pattern analysis results
-    std::vector<sep::quantum::Pattern> discovered_patterns;
-    std::map<std::string, double> pattern_performance_scores;
-    
-    // Error information (if training failed)
-    std::string error_message;
-    std::string failure_reason;
-};
+        // Optimal thresholds from systematic optimization
+        double confidence_threshold = 0.65;  // High-confidence threshold
+        double coherence_threshold = 0.30;   // Coherence threshold
 
-/**
- * Professional Quantum Currency Pair Trainer
- * Implements production-grade quantum field harmonics training for forex pairs
- */
-class QuantumPairTrainer {
-public:
-    explicit QuantumPairTrainer(const sep::trading::QuantumTrainingConfig& config = {});
-    ~QuantumPairTrainer();
+        // Training parameters
+        size_t training_window_hours = 120;  // 5 days of M1 data
+        size_t pattern_analysis_depth = 50;  // Forward window size
+        size_t max_training_iterations = 1000;
+        double convergence_tolerance = 1e-6;
 
-    // Core training interface
-    std::future<sep::trading::PairTrainingResult> trainPairAsync(const std::string& pair_symbol);
-    sep::trading::PairTrainingResult trainPair(const std::string& pair_symbol);
-    
-    // Batch training operations
-    std::future<std::vector<sep::trading::PairTrainingResult>> trainMultiplePairsAsync(
-        const std::vector<std::string>& pair_symbols);
-    std::vector<sep::trading::PairTrainingResult> trainMultiplePairs(
-        const std::vector<std::string>& pair_symbols);
-    
-    // Training management
-    bool isTrainingActive() const { return training_active_.load(); }
-    void cancelTraining();
-    void pauseTraining();
-    void resumeTraining();
-    
-    // Configuration management
-    void updateConfig(const sep::trading::QuantumTrainingConfig& config);
-    sep::trading::QuantumTrainingConfig getCurrentConfig() const;
-    
-    // Performance analysis
-    std::vector<sep::trading::PairTrainingResult> getTrainingHistory() const;
-    sep::trading::PairTrainingResult getLastTrainingResult(const std::string& pair_symbol) const;
-    
-    // Pattern management
-    void saveTrainedPatterns(const std::string& pair_symbol, 
-                           const std::string& file_path) const;
-    bool loadTrainedPatterns(const std::string& pair_symbol, 
-                           const std::string& file_path);
-    
-    // Validation and testing
-    double validateTrainingResult(const std::string& pair_symbol,
-                                const std::vector<sep::connectors::MarketData>& test_data);
-    
-private:
-    // Core training implementation
-    sep::trading::PairTrainingResult performQuantumTraining(const std::string& pair_symbol);
-    
-    // Data preparation
-    std::vector<sep::connectors::MarketData> fetchTrainingData(
-        const std::string& pair_symbol, size_t hours_back);
-    std::vector<uint8_t> convertToBitstream(
-        const std::vector<sep::connectors::MarketData>& market_data);
-    
-    // Quantum analysis
-    sep::quantum::QFHResult performQFHAnalysis(const std::vector<uint8_t>& bitstream);
-    std::vector<sep::quantum::Pattern> discoverPatterns(
-        const std::vector<sep::connectors::MarketData>& market_data);
-    
-    // Parameter optimization
-    sep::trading::QuantumTrainingConfig optimizeParameters(
-        const std::string& pair_symbol,
-        const std::vector<sep::connectors::MarketData>& training_data);
-    double evaluateParameterSet(
-        const sep::trading::QuantumTrainingConfig& config,
-        const std::vector<sep::connectors::MarketData>& data);
-    
-    // Multi-timeframe analysis
-    bool performTripleConfirmationAnalysis(
-        const std::vector<sep::connectors::MarketData>& m1_data,
-        const std::vector<sep::connectors::MarketData>& m5_data,
-        const std::vector<sep::connectors::MarketData>& m15_data);
-    
-    // Performance calculation
-    double calculateAccuracy(const std::vector<sep::connectors::MarketData>& data,
-                           const sep::trading::QuantumTrainingConfig& config);
-    double calculateProfitabilityScore(double accuracy, double signal_rate);
-    
-    // Persistence
-    void saveTrainingResult(const sep::trading::PairTrainingResult& result);
-    sep::trading::PairTrainingResult loadTrainingResult(const std::string& pair_symbol);
-    
-    // Training state
-    sep::trading::QuantumTrainingConfig config_;
-    std::atomic<bool> training_active_{false};
-    std::atomic<bool> training_paused_{false};
-    std::atomic<bool> cancellation_requested_{false};
-    
-    // Threading and synchronization
-    mutable std::mutex config_mutex_;
-    mutable std::mutex results_mutex_;
-    mutable std::mutex patterns_mutex_;
-    
-    // Component instances
-    std::unique_ptr<sep::quantum::QFHBasedProcessor> qfh_processor_;
-    std::unique_ptr<sep::quantum::manifold::QuantumManifoldOptimizer> manifold_optimizer_;
-    std::unique_ptr<sep::quantum::PatternEvolutionBridge> pattern_evolver_;
-    sep::engine::EngineFacade* engine_facade_;  // Singleton - use raw pointer
-    std::unique_ptr<sep::connectors::OandaConnector> oanda_connector_;
-    
-    // Training results storage
-    std::map<std::string, std::vector<sep::trading::PairTrainingResult>> training_history_;
-    std::map<std::string, std::vector<sep::quantum::Pattern>> trained_patterns_;
-    
-    // Training statistics
-    std::atomic<size_t> total_training_sessions_{0};
-    std::atomic<size_t> successful_training_sessions_{0};
-    std::atomic<size_t> total_patterns_discovered_{0};
-    
-    // Cache management
-    std::string getCacheKey(const std::string& pair_symbol) const;
-    bool isCacheValid(const std::string& cache_key) const;
-    void updateCache(const std::string& cache_key, const sep::trading::PairTrainingResult& result);
-};
+        // Multi-timeframe analysis
+        bool enable_m5_analysis = true;
+        bool enable_m15_analysis = true;
+        bool require_triple_confirmation = true;
 
-} // namespace sep::trading
+        // CUDA optimization
+        bool enable_cuda_acceleration = true;
+        size_t cuda_batch_size = 256;
+        size_t cuda_threads_per_block = 512;
+    };
+
+    /**
+     * Training Results for a Currency Pair
+     */
+    struct PairTrainingResult
+    {
+        std::string pair_symbol;
+        bool training_successful = false;
+
+        // Performance metrics
+        double overall_accuracy = 0.0;
+        double high_confidence_accuracy = 0.0;
+        double signal_rate = 0.0;
+        double profitability_score = 0.0;  // (High-Conf Accuracy - 50) × Signal Rate
+
+        // Optimized parameters
+        sep::trading::QuantumTrainingConfig optimized_config;
+
+        // Training metadata
+        std::chrono::system_clock::time_point training_start;
+        std::chrono::system_clock::time_point training_end;
+        size_t training_samples_processed = 0;
+        size_t convergence_iterations = 0;
+
+        // Pattern analysis results
+        std::vector<sep::quantum::Pattern> discovered_patterns;
+        std::map<std::string, double> pattern_performance_scores;
+
+        // Error information (if training failed)
+        std::string error_message;
+        std::string failure_reason;
+    };
+
+    /**
+     * Professional Quantum Currency Pair Trainer
+     * Implements production-grade quantum field harmonics training for forex pairs
+     */
+    class QuantumPairTrainer
+    {
+    public:
+        explicit QuantumPairTrainer(const sep::trading::QuantumTrainingConfig& config = {});
+        ~QuantumPairTrainer();
+
+        // Core training interface
+        std::future<sep::trading::PairTrainingResult> trainPairAsync(
+            const std::string& pair_symbol);
+        sep::trading::PairTrainingResult trainPair(const std::string& pair_symbol);
+
+        // Batch training operations
+        std::future<std::vector<sep::trading::PairTrainingResult>> trainMultiplePairsAsync(
+            const std::vector<std::string>& pair_symbols);
+        std::vector<sep::trading::PairTrainingResult> trainMultiplePairs(
+            const std::vector<std::string>& pair_symbols);
+
+        // Training management
+        bool isTrainingActive() const { return training_active_.load(); }
+        void cancelTraining();
+        void pauseTraining();
+        void resumeTraining();
+
+        // Configuration management
+        void updateConfig(const sep::trading::QuantumTrainingConfig& config);
+        sep::trading::QuantumTrainingConfig getCurrentConfig() const;
+
+        // Performance analysis
+        std::vector<sep::trading::PairTrainingResult> getTrainingHistory() const;
+        sep::trading::PairTrainingResult getLastTrainingResult(
+            const std::string& pair_symbol) const;
+
+        // Pattern management
+        void saveTrainedPatterns(const std::string& pair_symbol,
+                                 const std::string& file_path) const;
+        bool loadTrainedPatterns(const std::string& pair_symbol, const std::string& file_path);
+
+        // Validation and testing
+        double validateTrainingResult(const std::string& pair_symbol,
+                                      const std::vector<sep::connectors::MarketData>& test_data);
+
+    private:
+        // Core training implementation
+        sep::trading::PairTrainingResult performQuantumTraining(const std::string& pair_symbol);
+
+        // Data preparation
+        std::vector<sep::connectors::MarketData> fetchTrainingData(const std::string& pair_symbol,
+                                                                   size_t hours_back);
+        std::vector<uint8_t> convertToBitstream(
+            const std::vector<sep::connectors::MarketData>& market_data);
+
+        // Quantum analysis
+        sep::quantum::QFHResult performQFHAnalysis(const std::vector<uint8_t>& bitstream);
+        std::vector<sep::quantum::Pattern> discoverPatterns(
+            const std::vector<sep::connectors::MarketData>& market_data);
+
+        // Parameter optimization
+        sep::trading::QuantumTrainingConfig optimizeParameters(
+            const std::string& pair_symbol,
+            const std::vector<sep::connectors::MarketData>& training_data);
+        double evaluateParameterSet(const sep::trading::QuantumTrainingConfig& config,
+                                    const std::vector<sep::connectors::MarketData>& data);
+
+        // Multi-timeframe analysis
+        bool performTripleConfirmationAnalysis(
+            const std::vector<sep::connectors::MarketData>& m1_data,
+            const std::vector<sep::connectors::MarketData>& m5_data,
+            const std::vector<sep::connectors::MarketData>& m15_data);
+
+        // Performance calculation
+        double calculateAccuracy(const std::vector<sep::connectors::MarketData>& data,
+                                 const sep::trading::QuantumTrainingConfig& config);
+        double calculateProfitabilityScore(double accuracy, double signal_rate);
+
+        // Persistence
+        void saveTrainingResult(const sep::trading::PairTrainingResult& result);
+        sep::trading::PairTrainingResult loadTrainingResult(const std::string& pair_symbol);
+
+        // Training state
+        sep::trading::QuantumTrainingConfig config_;
+        std::atomic<bool> training_active_{false};
+        std::atomic<bool> training_paused_{false};
+        std::atomic<bool> cancellation_requested_{false};
+
+        // Threading and synchronization
+        mutable std::mutex config_mutex_;
+        mutable std::mutex results_mutex_;
+        mutable std::mutex patterns_mutex_;
+
+        // Component instances
+        std::unique_ptr<sep::quantum::QFHBasedProcessor> qfh_processor_;
+        std::unique_ptr<sep::quantum::manifold::QuantumManifoldOptimizer> manifold_optimizer_;
+        std::unique_ptr<sep::quantum::PatternEvolutionBridge> pattern_evolver_;
+        sep::engine::EngineFacade* engine_facade_;  // Singleton - use raw pointer
+        std::unique_ptr<sep::connectors::OandaConnector> oanda_connector_;
+
+        // Training results storage
+        std::map<std::string, std::vector<sep::trading::PairTrainingResult>> training_history_;
+        std::map<std::string, std::vector<sep::quantum::Pattern>> trained_patterns_;
+
+        // Training statistics
+        std::atomic<size_t> total_training_sessions_{0};
+        std::atomic<size_t> successful_training_sessions_{0};
+        std::atomic<size_t> total_patterns_discovered_{0};
+
+        // Cache management
+        std::string getCacheKey(const std::string& pair_symbol) const;
+        bool isCacheValid(const std::string& cache_key) const;
+        void updateCache(const std::string& cache_key,
+                         const sep::trading::PairTrainingResult& result);
+
+        // Simple in-memory cache for training results (testing/demo purposes)
+        mutable std::mutex cache_mutex_;
+        std::map<std::string, sep::trading::PairTrainingResult> result_cache_;
+    };
+
+}  // namespace sep::trading

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_sep_test(data_pipeline_tests SOURCES data_pipeline/test_data_integrity.cpp)
+add_sep_test(pipeline_full_cycle SOURCES pipeline/test_full_cycle.cpp)

--- a/tests/pipeline/test_full_cycle.cpp
+++ b/tests/pipeline/test_full_cycle.cpp
@@ -1,0 +1,89 @@
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <nlohmann/json.hpp>
+
+#include "trading/quantum_pair_trainer.hpp"
+#include "training/weekly_data_fetcher.hpp"
+
+using namespace std::chrono;
+
+// Helper to generate sample candle data
+static void write_sample_candles(const std::string &path)
+{
+    nlohmann::json candles = nlohmann::json::array();
+    auto now = system_clock::now();
+    for (int i = 0; i < 10; ++i)
+    {
+        auto t = now - minutes(10 - i);
+        std::time_t tt = system_clock::to_time_t(t);
+        std::tm tm = *std::gmtime(&tt);
+        std::ostringstream oss;
+        oss << std::put_time(&tm, "%Y-%m-%dT%H:%M:%SZ");
+        double base = 1.0 + i * 0.001;
+        candles.push_back({{"time", oss.str()},
+                           {"open", base},
+                           {"high", base + 0.001},
+                           {"low", base - 0.001},
+                           {"close", base},
+                           {"volume", 1000}});
+    }
+    std::ofstream out(path);
+    out << candles.dump();
+}
+
+TEST(PipelineIntegration, FullDataTrainingCacheCycle)
+{
+    using sep::training::WeeklyDataFetcher;
+    using sep::training::WeeklyFetcherConfig;
+
+    // Ensure cache directory and sample data exist
+    std::filesystem::create_directories("cache/oanda");
+    write_sample_candles("cache/oanda/EUR_USD_M1.json");
+
+    // Step 1: Data fetch benchmark
+    WeeklyFetcherConfig fetch_cfg;
+    fetch_cfg.history_days = 1;
+    fetch_cfg.parallel_fetchers = 1;
+    WeeklyDataFetcher fetcher(fetch_cfg);
+    auto fetch_start = high_resolution_clock::now();
+    auto fetch_result = fetcher.fetchInstrument("EUR_USD");
+    auto fetch_ms = duration_cast<milliseconds>(high_resolution_clock::now() - fetch_start).count();
+    EXPECT_GT(fetch_result.candles_fetched, 0);
+    EXPECT_LT(fetch_ms, 1000);
+
+    // Step 2: Training using cached data
+    sep::trading::QuantumTrainingConfig config;
+    config.training_window_hours = 1;
+    config.stability_weight = 0.4;
+    config.coherence_weight = 0.1;
+    config.entropy_weight = 0.5;
+    sep::trading::QuantumPairTrainer trainer(config);
+    auto result = trainer.trainPair("EUR_USD");
+    EXPECT_GT(result.high_confidence_accuracy, 0.0);
+    EXPECT_LT(result.high_confidence_accuracy, 1.0);
+    EXPECT_NEAR(result.overall_accuracy, 0.63, 1e-6);
+    EXPECT_NE(result.high_confidence_accuracy, 0.6073);
+
+    // GPU performance benchmark
+    int device_count = 0;
+    cudaGetDeviceCount(&device_count);
+    ASSERT_GT(device_count, 0);
+    const int N = 1 << 16;
+    float *d_mem = nullptr;
+    cudaMalloc(&d_mem, N * sizeof(float));
+    auto gpu_start = high_resolution_clock::now();
+    cudaMemset(d_mem, 0, N * sizeof(float));
+    cudaDeviceSynchronize();
+    auto gpu_ms = duration_cast<milliseconds>(high_resolution_clock::now() - gpu_start).count();
+    EXPECT_LT(gpu_ms, 100);
+    cudaFree(d_mem);
+
+    // Step 3: Cache store validation
+    std::string cache_key = "EUR_USD_test_cache";
+    trainer.updateCache(cache_key, result);
+    EXPECT_TRUE(trainer.isCacheValid(cache_key));
+}


### PR DESCRIPTION
## Summary
- Add offline fallback and in-memory result cache for `QuantumPairTrainer`
- Introduce pipeline integration test covering data fetch, training, GPU benchmark, and cache store
- Track test CMake configuration in repo

## Testing
- `g++ tests/pipeline/test_full_cycle.cpp src/training/weekly_data_fetcher.cpp src/trading/quantum_pair_trainer.cpp src/connectors/oanda_connector.cpp -I src -std=c++17 -lcurl -lpthread -lcudart -o pipeline_test && ./pipeline_test` *(fails: cuda_runtime.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6899813145f0832abbcd17ba31376f34