### PR TITLE
Add pipeline integration tests and stub detection

### DIFF
--- a/src/training/training_coordinator.cpp
+++ b/src/training/training_coordinator.cpp
@@ -1,11 +1,12 @@
 // SEP Professional Training Coordinator Implementation
 // Coordinates local CUDA training with remote trading deployment
 
-#include "common/sep_precompiled.h"
 #include "training_coordinator.hpp"
-#include "trading/quantum_pair_trainer.hpp"
-#include "connectors/oanda_connector.h"
+
 #include "cache/weekly_cache_manager.hpp"
+#include "common/sep_precompiled.h"
+#include "connectors/oanda_connector.h"
+#include "trading/quantum_pair_trainer.hpp"
 
 // Restore array if corrupted
 #ifdef array
@@ -17,226 +18,268 @@
 
 using namespace sep::training;
 
-TrainingCoordinator::TrainingCoordinator() 
-    : remote_connected_(false), sync_running_(false), live_tuning_active_(false) {
-    
-    if (!initializeComponents()) {
+TrainingCoordinator::TrainingCoordinator()
+    : remote_connected_(false), sync_running_(false), live_tuning_active_(false)
+{
+    if (!initializeComponents())
+    {
         throw std::runtime_error("Failed to initialize training coordinator");
     }
-    
+
     loadTrainingResults();
 }
 
-TrainingCoordinator::~TrainingCoordinator() {
+TrainingCoordinator::~TrainingCoordinator()
+{
     // Stop all running threads
-    if (sync_running_) {
+    if (sync_running_)
+    {
         sync_running_ = false;
-        if (sync_thread_.joinable()) {
+        if (sync_thread_.joinable())
+        {
             sync_thread_.join();
         }
     }
-    
-    if (live_tuning_active_) {
+
+    if (live_tuning_active_)
+    {
         stopLiveTuning();
     }
 }
 
-bool TrainingCoordinator::initializeComponents() {
-    try {
+bool TrainingCoordinator::initializeComponents()
+{
+    try
+    {
         // Initialize configuration manager
         config_manager_ = std::make_unique<config::DynamicConfigManager>();
-        
-        // Initialize cache manager  
+
+        // Initialize cache manager
         cache_manager_ = std::make_unique<cache::WeeklyCacheManager>();
-        
+
         // Set up OANDA data source provider for cache manager
-        cache_manager_->setDataSourceProvider([](const std::string& pair_symbol, 
-                                                std::chrono::system_clock::time_point from,
-                                                std::chrono::system_clock::time_point to) -> std::vector<std::string> {
-            
-            const char* api_key = std::getenv("OANDA_API_KEY");
-            const char* account_id = std::getenv("OANDA_ACCOUNT_ID");
-            
-            if (!api_key || !account_id) {
-                spdlog::warn("OANDA credentials not available for data fetching");
-                return {};
-            }
-            
-            try {
-                auto oanda_connector = std::make_unique<sep::connectors::OandaConnector>(api_key, account_id, true);
-                if (!oanda_connector->initialize()) {
-                    spdlog::error("Failed to initialize OANDA connector for cache data");
+        cache_manager_->setDataSourceProvider(
+            [](const std::string& pair_symbol, std::chrono::system_clock::time_point from,
+               std::chrono::system_clock::time_point to) -> std::vector<std::string> {
+                const char* api_key = std::getenv("OANDA_API_KEY");
+                const char* account_id = std::getenv("OANDA_ACCOUNT_ID");
+
+                if (!api_key || !account_id)
+                {
+                    spdlog::warn("OANDA credentials not available for data fetching");
                     return {};
                 }
-                
-                // Convert time points to ISO 8601 strings
-                auto time_t_from = std::chrono::system_clock::to_time_t(from);
-                auto time_t_to = std::chrono::system_clock::to_time_t(to);
-                
-                char from_str[32];
-                char to_str[32]; 
-                strftime(from_str, sizeof(from_str), "%Y-%m-%dT%H:%M:%S.000000000Z", gmtime(&time_t_from));
-                strftime(to_str, sizeof(to_str), "%Y-%m-%dT%H:%M:%S.000000000Z", gmtime(&time_t_to));
-                
-                // Fetch historical data from OANDA
-                auto candles = oanda_connector->getHistoricalData(pair_symbol, "M1", from_str, to_str);
-                
-                // Convert candles to string format for cache storage
-                std::vector<std::string> result;
-                for (const auto& candle : candles) {
-                    nlohmann::json candle_json;
-                    candle_json["timestamp"] = candle.timestamp;
-                    candle_json["open"] = candle.open;
-                    candle_json["high"] = candle.high;
-                    candle_json["low"] = candle.low;
-                    candle_json["close"] = candle.close;
-                    candle_json["volume"] = candle.volume;
-                    result.push_back(candle_json.dump());
+
+                try
+                {
+                    auto oanda_connector = std::make_unique<sep::connectors::OandaConnector>(
+                        api_key, account_id, true);
+                    if (!oanda_connector->initialize())
+                    {
+                        spdlog::error("Failed to initialize OANDA connector for cache data");
+                        return {};
+                    }
+
+                    // Convert time points to ISO 8601 strings
+                    auto time_t_from = std::chrono::system_clock::to_time_t(from);
+                    auto time_t_to = std::chrono::system_clock::to_time_t(to);
+
+                    char from_str[32];
+                    char to_str[32];
+                    strftime(from_str, sizeof(from_str), "%Y-%m-%dT%H:%M:%S.000000000Z",
+                             gmtime(&time_t_from));
+                    strftime(to_str, sizeof(to_str), "%Y-%m-%dT%H:%M:%S.000000000Z",
+                             gmtime(&time_t_to));
+
+                    // Fetch historical data from OANDA
+                    auto candles =
+                        oanda_connector->getHistoricalData(pair_symbol, "M1", from_str, to_str);
+
+                    // Convert candles to string format for cache storage
+                    std::vector<std::string> result;
+                    for (const auto& candle : candles)
+                    {
+                        nlohmann::json candle_json;
+                        candle_json["timestamp"] = candle.timestamp;
+                        candle_json["open"] = candle.open;
+                        candle_json["high"] = candle.high;
+                        candle_json["low"] = candle.low;
+                        candle_json["close"] = candle.close;
+                        candle_json["volume"] = candle.volume;
+                        result.push_back(candle_json.dump());
+                    }
+
+                    spdlog::info("Fetched {} candles for {} from OANDA", result.size(),
+                                 pair_symbol);
+                    return result;
                 }
-                
-                spdlog::info("Fetched {} candles for {} from OANDA", result.size(), pair_symbol);
-                return result;
-                
-            } catch (const std::exception& e) {
-                spdlog::error("Error fetching OANDA data for cache: {}", e.what());
-                return {};
-            }
-        });
-        
+                catch (const std::exception& e)
+                {
+                    spdlog::error("Error fetching OANDA data for cache: {}", e.what());
+                    return {};
+                }
+            });
+
         return true;
-    } catch (const std::exception& e) {
+    }
+    catch (const std::exception& e)
+    {
         std::cerr << "Failed to initialize components: " << e.what() << std::endl;
         return false;
     }
 }
 
-bool TrainingCoordinator::trainPair(const std::string& pair, TrainingMode mode) {
-    std::cout << "🔧 Training " << pair << " in " 
+bool TrainingCoordinator::trainPair(const std::string& pair, TrainingMode mode)
+{
+    std::cout << "🔧 Training " << pair << " in "
               << (mode == TrainingMode::QUICK ? "QUICK" : "FULL") << " mode..." << std::endl;
-    
-    try {
+
+    try
+    {
         auto result = executeCudaTraining(pair, mode);
-        
-        if (result.quality != PatternQuality::UNKNOWN) {
+
+        if (result.quality != PatternQuality::UNKNOWN)
+        {
             std::lock_guard<std::mutex> lock(results_mutex_);
             training_results_[pair] = result;
             last_trained_[pair] = std::chrono::system_clock::now();
-            
+
             saveTrainingResult(result);
-            
-            std::cout << "✅ " << pair << " training completed - " 
-                      << result.accuracy << "% accuracy" << std::endl;
+
+            std::cout << "✅ " << pair << " training completed - " << result.accuracy
+                      << "% accuracy" << std::endl;
             return true;
         }
-        
+
         return false;
-        
-    } catch (const std::exception& e) {
+    }
+    catch (const std::exception& e)
+    {
         std::cerr << "❌ Training failed for " << pair << ": " << e.what() << std::endl;
         return false;
     }
 }
 
-TrainingResult TrainingCoordinator::executeCudaTraining(const std::string& pair, TrainingMode mode) {
+TrainingResult TrainingCoordinator::executeCudaTraining(const std::string& pair, TrainingMode mode)
+{
     TrainingResult result;
     result.pair = pair;
     result.trained_at = std::chrono::system_clock::now();
-    
+
     // Real CUDA training implementation - replaced simulation stub
-    try {
-        #ifdef __CUDACC__
+    try
+    {
+#ifdef __CUDACC__
         // Launch actual CUDA training kernels
         std::vector<float> training_data(1000, 1.0f);
         std::vector<float> results(1000, 0.0f);
-        
+
         // Use real market data from OANDA - we have this available now
         sep::trading::QuantumTrainingConfig config;
         sep::trading::QuantumPairTrainer trainer(config);
-        
+
         // Fetch real OANDA market data for training
-        auto market_data = trainer.fetchTrainingData(pair, 24); // 24 hours of real data
-        
-        if (!market_data.empty()) {
+        auto market_data = trainer.fetchTrainingData(pair, 24);  // 24 hours of real data
+
+        if (!market_data.empty())
+        {
             // Convert market data to training format
             std::vector<float> price_data;
             price_data.reserve(market_data.size());
-            for (const auto& md : market_data) {
+            for (const auto& md : market_data)
+            {
                 price_data.push_back(static_cast<float>(md.mid));
             }
-            
+
             // Launch actual CUDA training with real market data
             launch_quantum_training(price_data.data(), results.data(), price_data.size(), 10);
-        } else {
+        }
+        else
+        {
             throw std::runtime_error("No market data available for training");
         }
-        
+
         // Calculate real accuracy from CUDA results
         float total_accuracy = 0.0f;
-        for (const auto& val : results) {
+        for (const auto& val : results)
+        {
             total_accuracy += val;
         }
         result.accuracy = (total_accuracy / results.size()) * 100.0;
-        
+
         // Set realistic bounds based on actual computation
         result.stability_score = std::min(0.95, std::max(0.5, result.accuracy / 100.0));
         result.coherence_score = std::min(0.90, std::max(0.4, result.accuracy / 120.0));
         result.entropy_score = std::min(0.85, std::max(0.3, result.accuracy / 150.0));
-        
-        #else
+
+#else
         // CPU fallback - still better than pure simulation
-        result.accuracy = 60.73; // Use proven baseline
+        result.accuracy = 60.73;  // Use proven baseline
         result.stability_score = 0.75;
         result.coherence_score = 0.65;
         result.entropy_score = 0.55;
-        #endif
-        
-    } catch (const std::exception& e) {
+#endif
+    }
+    catch (const std::exception& e)
+    {
         // Fallback to baseline if CUDA training fails
-        result.accuracy = 60.73; // Proven performance baseline
+        result.accuracy = 60.73;  // Proven performance baseline
         result.stability_score = 0.75;
         result.coherence_score = 0.65;
         result.entropy_score = 0.55;
+    }
+    if (result.accuracy == 60.73 && result.stability_score == 0.75 &&
+        result.coherence_score == 0.65 && result.entropy_score == 0.55)
+    {
+        throw std::runtime_error("Stub training values detected");
     }
     result.quality = assessPatternQuality(result.accuracy);
     result.model_hash = generateModelHash(result);
-    
+
     // Set training parameters based on mode
-    if (mode == TrainingMode::QUICK) {
+    if (mode == TrainingMode::QUICK)
+    {
         result.parameters["iterations"] = 100;
         result.parameters["batch_size"] = 512;
-    } else {
+    }
+    else
+    {
         result.parameters["iterations"] = 1000;
         result.parameters["batch_size"] = 1024;
     }
-    
+
     return result;
 }
 
-bool TrainingCoordinator::trainAllPairs(TrainingMode mode) {
-    std::vector<std::string> pairs = {
-        "EUR_USD", "GBP_USD", "USD_JPY", "AUD_USD", "USD_CHF", "USD_CAD"
-    };
-    
+bool TrainingCoordinator::trainAllPairs(TrainingMode mode)
+{
+    std::vector<std::string> pairs = {"EUR_USD", "GBP_USD", "USD_JPY",
+                                      "AUD_USD", "USD_CHF", "USD_CAD"};
+
     std::cout << "🔧 Training " << pairs.size() << " pairs..." << std::endl;
-    
+
     bool all_success = true;
-    for (size_t i = 0; i < pairs.size(); ++i) {
-        std::cout << "[" << (i+1) << "/" << pairs.size() << "] ";
-        if (!trainPair(pairs[i], mode)) {
+    for (size_t i = 0; i < pairs.size(); ++i)
+    {
+        std::cout << "[" << (i + 1) << "/" << pairs.size() << "] ";
+        if (!trainPair(pairs[i], mode))
+        {
             all_success = false;
         }
     }
-    
+
     return all_success;
 }
 
-TrainingResult TrainingCoordinator::getTrainingResult(const std::string& pair) const {
+TrainingResult TrainingCoordinator::getTrainingResult(const std::string& pair) const
+{
     std::lock_guard<std::mutex> lock(results_mutex_);
     auto it = training_results_.find(pair);
-    if (it != training_results_.end()) {
+    if (it != training_results_.end())
+    {
         return it->second;
     }
-    
+
     // Return empty result
     TrainingResult empty;
     empty.pair = pair;
@@ -244,75 +287,85 @@ TrainingResult TrainingCoordinator::getTrainingResult(const std::string& pair) c
     return empty;
 }
 
-std::map<std::string, std::string> TrainingCoordinator::getSystemStatus() const {
+std::map<std::string, std::string> TrainingCoordinator::getSystemStatus() const
+{
     std::map<std::string, std::string> status;
-    
+
     status["status"] = "ready";
     status["training_pairs"] = std::to_string(training_results_.size());
     status["remote_connected"] = remote_connected_ ? "true" : "false";
     status["live_tuning"] = live_tuning_active_ ? "active" : "inactive";
-    
+
     return status;
 }
 
-bool TrainingCoordinator::configureRemoteTrader(const RemoteTraderConfig& config) {
+bool TrainingCoordinator::configureRemoteTrader(const RemoteTraderConfig& config)
+{
     remote_config_ = config;
-    
+
     // Test connection
-    std::cout << "🌐 Testing connection to " << config.host << ":" << config.port << "..." << std::endl;
-    
+    std::cout << "🌐 Testing connection to " << config.host << ":" << config.port << "..."
+              << std::endl;
+
     // Simulate connection test
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     remote_connected_ = true;
-    
+
     std::cout << "✅ Remote trader connection configured" << std::endl;
     return true;
 }
 
-bool TrainingCoordinator::syncPatternsToRemote() {
-    if (!remote_connected_) {
+bool TrainingCoordinator::syncPatternsToRemote()
+{
+    if (!remote_connected_)
+    {
         std::cout << "❌ Remote trader not connected" << std::endl;
         return false;
     }
-    
+
     std::cout << "🔄 Syncing patterns to remote trader..." << std::endl;
-    
+
     // Simulate pattern sync
     std::this_thread::sleep_for(std::chrono::milliseconds(300));
-    
+
     std::cout << "✅ Patterns synchronized successfully" << std::endl;
     return true;
 }
 
-bool TrainingCoordinator::fetchWeeklyDataForAll() {
+bool TrainingCoordinator::fetchWeeklyDataForAll()
+{
     std::cout << "📥 Fetching weekly data for all instruments..." << std::endl;
-    
+
     // Simulate data fetching
     std::this_thread::sleep_for(std::chrono::seconds(2));
-    
+
     std::cout << "✅ Weekly data fetch completed" << std::endl;
     return true;
 }
 
-PatternQuality TrainingCoordinator::assessPatternQuality(double accuracy) const {
+PatternQuality TrainingCoordinator::assessPatternQuality(double accuracy) const
+{
     if (accuracy >= 70.0) return PatternQuality::HIGH;
     if (accuracy >= 60.0) return PatternQuality::MEDIUM;
     return PatternQuality::LOW;
 }
 
-std::string TrainingCoordinator::generateModelHash(const TrainingResult& result) const {
+std::string TrainingCoordinator::generateModelHash(const TrainingResult& result) const
+{
     std::ostringstream oss;
-    oss << result.pair << "_" << result.accuracy << "_" 
-        << std::chrono::duration_cast<std::chrono::seconds>(
-            result.trained_at.time_since_epoch()).count();
+    oss << result.pair << "_" << result.accuracy << "_"
+        << std::chrono::duration_cast<std::chrono::seconds>(result.trained_at.time_since_epoch())
+               .count();
     return std::to_string(std::hash<std::string>{}(oss.str()));
 }
 
-bool TrainingCoordinator::saveTrainingResult(const TrainingResult& result) {
+bool TrainingCoordinator::saveTrainingResult(const TrainingResult& result)
+{
     // Save to JSON file (simplified implementation)
     std::string filename = "cache/training_result_" + result.pair + ".json";
     std::ofstream file(filename);
-    if (file.is_open()) {
+    if (file.is_open())
+    {
         file << "{\n";
         file << "  \"pair\": \"" << result.pair << "\",\n";
         file << "  \"accuracy\": " << result.accuracy << ",\n";
@@ -325,92 +378,102 @@ bool TrainingCoordinator::saveTrainingResult(const TrainingResult& result) {
     return false;
 }
 
-bool TrainingCoordinator::loadTrainingResults() {
+bool TrainingCoordinator::loadTrainingResults()
+{
     // Load existing training results from cache
     // Simplified implementation for now
     return true;
 }
 
-std::vector<TrainingResult> TrainingCoordinator::getAllResults() const {
+std::vector<TrainingResult> TrainingCoordinator::getAllResults() const
+{
     std::lock_guard<std::mutex> lock(results_mutex_);
     std::vector<TrainingResult> results;
-    for (const auto& pair : training_results_) {
+    for (const auto& pair : training_results_)
+    {
         results.push_back(pair.second);
     }
     return results;
 }
 
-bool TrainingCoordinator::startLiveTuning(const std::vector<std::string>& pairs) {
-    if (live_tuning_active_) {
+bool TrainingCoordinator::startLiveTuning(const std::vector<std::string>& pairs)
+{
+    if (live_tuning_active_)
+    {
         std::cout << "⚠️  Live tuning already active" << std::endl;
         return false;
     }
-    
+
     live_tuning_active_ = true;
     std::cout << "🎯 Starting live tuning for " << pairs.size() << " pairs..." << std::endl;
-    
+
     // Start tuning thread
     tuning_thread_ = std::thread(&TrainingCoordinator::liveTuningThreadFunction, this);
-    
+
     return true;
 }
 
-bool TrainingCoordinator::stopLiveTuning() {
-    if (!live_tuning_active_) {
+bool TrainingCoordinator::stopLiveTuning()
+{
+    if (!live_tuning_active_)
+    {
         return false;
     }
-    
+
     live_tuning_active_ = false;
     tuning_cv_.notify_all();
-    
-    if (tuning_thread_.joinable()) {
+
+    if (tuning_thread_.joinable())
+    {
         tuning_thread_.join();
     }
-    
+
     std::cout << "⏹️  Live tuning stopped" << std::endl;
     return true;
 }
 
-void TrainingCoordinator::liveTuningThreadFunction() {
-    while (live_tuning_active_) {
+void TrainingCoordinator::liveTuningThreadFunction()
+{
+    while (live_tuning_active_)
+    {
         // Simulate live tuning work
         std::this_thread::sleep_for(std::chrono::seconds(5));
-        
-        if (live_tuning_active_) {
+
+        if (live_tuning_active_)
+        {
             std::cout << "🔄 Live tuning iteration..." << std::endl;
         }
     }
 }
 
-bool TrainingCoordinator::isLiveTuningActive() const {
-    return live_tuning_active_;
-}
+bool TrainingCoordinator::isLiveTuningActive() const { return live_tuning_active_; }
 
-bool TrainingCoordinator::isRemoteTraderConnected() const {
-    return remote_connected_;
-}
+bool TrainingCoordinator::isRemoteTraderConnected() const { return remote_connected_; }
 
-bool TrainingCoordinator::fetchWeeklyDataForPair(const std::string& pair) {
+bool TrainingCoordinator::fetchWeeklyDataForPair(const std::string& pair)
+{
     std::cout << "📥 Fetching weekly data for " << pair << "..." << std::endl;
-    
+
     // Simulate data fetching
     std::this_thread::sleep_for(std::chrono::milliseconds(500));
-    
+
     std::cout << "✅ Weekly data fetched for " << pair << std::endl;
     return true;
 }
 
-bool TrainingCoordinator::syncParametersFromRemote() {
-    if (!remote_connected_) {
+bool TrainingCoordinator::syncParametersFromRemote()
+{
+    if (!remote_connected_)
+    {
         std::cout << "❌ Remote trader not connected" << std::endl;
         return false;
     }
-    
+
     std::cout << "🔄 Syncing parameters from remote trader..." << std::endl;
-    
+
     // Simulate parameter sync
     std::this_thread::sleep_for(std::chrono::milliseconds(300));
-    
+
     std::cout << "✅ Parameters synchronized successfully" << std::endl;
     return true;
 }

--- a/tests/pipeline/test_full_cycle.cpp
+++ b/tests/pipeline/test_full_cycle.cpp
@@ -1,0 +1,104 @@
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <fstream>
+#include <nlohmann/json.hpp>
+#include <vector>
+
+#include "apps/oanda_trader/candle_types.h"
+#include "apps/oanda_trader/realtime_aggregator.hpp"
+
+#if __has_include(<cuda_runtime.h>)
+#include <cuda_runtime.h>
+extern "C" void launch_quantum_training(const float* input_data, float* output_patterns,
+                                        int data_size, int pattern_count);
+#define SEP_HAS_CUDA 1
+#else
+#define SEP_HAS_CUDA 0
+#endif
+
+TEST(PipelineIntegration, FullDataFetchTrainingCache)
+{
+    system("mkdir -p /_sep/testbed");
+    std::ifstream file("assets/test_data/eur_usd_m1_48h.json");
+    ASSERT_TRUE(file.is_open());
+    nlohmann::json json_data;
+    file >> json_data;
+    std::vector<float> prices;
+    for (const auto& c : json_data)
+    {
+        prices.push_back(static_cast<float>(c["close"]));
+    }
+    ASSERT_FALSE(prices.empty());
+
+#if SEP_HAS_CUDA
+    int device_count = 0;
+    cudaGetDeviceCount(&device_count);
+    if (device_count == 0)
+    {
+        GTEST_SKIP() << "No CUDA device available";
+    }
+    std::vector<float> results(prices.size());
+    auto start = std::chrono::high_resolution_clock::now();
+    launch_quantum_training(prices.data(), results.data(), prices.size(), 10);
+    cudaDeviceSynchronize();
+    auto end = std::chrono::high_resolution_clock::now();
+    auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
+    EXPECT_LT(ms, 200);
+
+    float avg = 0.0f;
+    for (float r : results) avg += r;
+    avg = (avg / results.size()) * 100.0f;
+    EXPECT_NEAR(avg, 50.0f, 50.0f);
+    EXPECT_NE(avg, 60.73f) << "Stub accuracy detected";
+#else
+    GTEST_SKIP() << "CUDA headers not available";
+    float avg = 0.0f;  // avoid unused warning
+#endif
+
+    nlohmann::json out_json;
+    out_json["accuracy"] = avg;
+    std::string out_path = "/_sep/testbed/training_cache.json";
+    {
+        std::ofstream out(out_path);
+        ASSERT_TRUE(out.is_open());
+        out << out_json.dump();
+    }
+    std::ifstream verify(out_path);
+    ASSERT_TRUE(verify.is_open());
+    nlohmann::json verify_json;
+    verify >> verify_json;
+#if SEP_HAS_CUDA
+    EXPECT_DOUBLE_EQ(verify_json["accuracy"], out_json["accuracy"]);
+#endif
+}
+
+TEST(PipelineIntegration, RealTimeCandleGenerationBenchmark)
+{
+    std::ifstream file("assets/test_data/eur_usd_m1_48h.json");
+    ASSERT_TRUE(file.is_open());
+    nlohmann::json json_data;
+    file >> json_data;
+
+    std::vector<Candle> generated;
+    RealTimeAggregator agg([&](const Candle& c, int tf) { generated.push_back(c); });
+
+    auto start = std::chrono::high_resolution_clock::now();
+    for (size_t i = 0; i < std::min<size_t>(json_data.size(), 300); ++i)
+    {
+        const auto& cj = json_data[i];
+        Candle c;
+        c.time = cj["time"];
+        c.timestamp = parseTimestamp(c.time);
+        c.open = cj["open"];
+        c.high = cj["high"];
+        c.low = cj["low"];
+        c.close = cj["close"];
+        c.volume = cj["volume"];
+        agg.addM1Candle(c);
+    }
+    auto end = std::chrono::high_resolution_clock::now();
+    auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
+    EXPECT_LT(ms, 100);
+    EXPECT_GT(generated.size(), 0u);
+}


### PR DESCRIPTION
## Summary
- Detect stub training values in `TrainingCoordinator` to prevent hardcoded accuracy from slipping through
- Add integration suite exercising data fetch, training, cache store, and real-time candle benchmarks

## Testing
- `g++ -std=c++17 tests/pipeline/test_full_cycle.cpp src/apps/oanda_trader/realtime_aggregator.cpp -Isrc -I/usr/include -lgtest -lgtest_main -lpthread -o tests/pipeline/test_full_cycle`
- `./tests/pipeline/test_full_cycle`


------
https://chatgpt.com/codex/tasks/task_e_68998131bc48832a8b2240aa5869846b