### PR TITLE
docs: add sync workflow and import instructions

### DIFF
--- a/docs/sync-workflow.md
+++ b/docs/sync-workflow.md
@@ -1,0 +1,36 @@
+# Syncing Training Results to the Trading Droplet
+
+After running local CUDA training, push the generated metrics and models to the remote droplet:
+
+```bash
+./scripts/sync_to_droplet.sh
+```
+
+This script copies the latest outputs to `/opt/sep-trader/data` on the droplet.
+
+## Import Metrics into Redis
+
+Use SSH to load the newest metric snapshot into Redis on the droplet. Replace `<PAIR>` with the currency pair you trained:
+
+```bash
+ssh root@YOUR_DROPLET_IP "cd /opt/sep-trader/sep-trader && ./build/src/cli/trader-cli data import /opt/sep-trader/data/latest_metrics_<PAIR>.rdb"
+```
+
+## Troubleshooting
+
+### Missing metrics file
+- Ensure the sync script completed successfully.
+- Verify the file exists on the droplet:
+  ```bash
+  ssh root@YOUR_DROPLET_IP "ls /opt/sep-trader/data"
+  ```
+  Confirm `latest_metrics_<PAIR>.rdb` appears with the correct pair name.
+
+### Redis connection errors
+- The import command reports issues like `Connection refused` or `Unable to reach Redis` when the Redis service is offline.
+- Check Redis status and restart if needed:
+  ```bash
+  ssh root@YOUR_DROPLET_IP "docker-compose ps redis"
+  ssh root@YOUR_DROPLET_IP "docker-compose restart redis"
+  ```
+- Run `redis-cli ping` to confirm connectivity before re-running the import.


### PR DESCRIPTION
## Summary
- document `scripts/sync_to_droplet.sh` usage after training
- add SSH-based `trader-cli` data import command
- include troubleshooting for missing files and Redis issues

## Testing
- no tests were run

------
https://chatgpt.com/codex/tasks/task_e_689984c5f31c832aa86ea2974da4d359