### PR TITLE
Add data import command to trader CLI

### DIFF
--- a/src/cli/trader_cli.hpp
+++ b/src/cli/trader_cli.hpp
@@ -45,6 +45,7 @@ private:
     int handle_config(const std::vector<std::string>& args);
     int handle_logs(const std::vector<std::string>& args);
     int handle_metrics(const std::vector<std::string>& args);
+    int handle_data_import(const std::vector<std::string>& args);
 
     // New command handlers for trading/quantum functionality
     int handle_trading(const std::vector<std::string>& args);


### PR DESCRIPTION
## Summary
- Add `handle_data_import` handler and register new `data import` command
- Implement RDB file parsing and Redis loading via `createRedisManager`
- Document `data import <file>` usage in CLI help

## Testing
- `./build.sh --no-docker` *(fails: Configuring incomplete, errors occurred; ninja: error: loading 'build.ninja')*


------
https://chatgpt.com/codex/tasks/task_e_689984bfe0f8832aa555c23037fc8761