### PR TITLE
docs: add CUDA kernel consolidation analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ docker-compose logs -f sep-trader
 - **[docs/SYSTEM_OVERVIEW.md](docs/SYSTEM_OVERVIEW.md)** - Complete architecture overview
 - **[docs/PROJECT_STATUS.md](docs/PROJECT_STATUS.md)** - Current implementation status
 - **[docs/CLOUD_DEPLOYMENT.md](docs/CLOUD_DEPLOYMENT.md)** - Cloud deployment guide
+- **[docs/cuda_kernel_consolidation_analysis.md](docs/cuda_kernel_consolidation_analysis.md)** - CUDA kernel locations and consolidation plan
 
 ## 🔒 Intellectual Property
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -718,4 +718,4 @@ The fragmented architecture makes the build system overly complex with duplicate
 
 ## Documentation TODOs
 
-- [ ] @docs/cuda_kernel_consolidation_analysis.md
+- [x] @docs/cuda_kernel_consolidation_analysis.md


### PR DESCRIPTION
## Summary
- document current CUDA kernel locations and duplicates
- outline consolidation plan for pattern and quantum kernels
- link analysis from README and mark TODO entry complete

## Testing
- no tests run (documentation changes only)

------
https://chatgpt.com/codex/tasks/task_e_689986cd2f38832abe06c67121024509