### PR TITLE
Add mock tick stream and realtime candle test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -267,3 +267,6 @@ cmake-build-*/
 *_generated.*
 !*_template.*
 config/OANDA.env
+!_sep/
+!_sep/testbed/
+!_sep/testbed/*

--- a/_sep/testbed/candle_assembler.h
+++ b/_sep/testbed/candle_assembler.h
@@ -1,0 +1,61 @@
+#pragma once
+#include <functional>
+#include <algorithm>
+#include <cstring>
+#include "mock_tick_stream.h"
+#include "core_types/candle_data.h"
+
+// Assembles ticks into fixed-period candles
+class CandleAssembler {
+public:
+    using Tick = MockTickStream::Tick;
+    using Candle = sep::core::CandleData;
+    using Callback = std::function<void(const Candle&)>;
+
+    CandleAssembler(uint64_t period_ms, Callback cb)
+        : period_ms_(period_ms), callback_(std::move(cb)) {}
+
+    void onTick(const Tick& tick) {
+        if (!has_candle_) {
+            startNewCandle(tick);
+            return;
+        }
+        if (tick.timestamp >= candle_start_ + period_ms_) {
+            finalize();
+            startNewCandle(tick);
+        } else {
+            updateCandle(tick);
+        }
+    }
+
+    void finalize() {
+        if (has_candle_) {
+            callback_(current_);
+            has_candle_ = false;
+        }
+    }
+
+private:
+    void startNewCandle(const Tick& tick) {
+        candle_start_ = tick.timestamp - (tick.timestamp % period_ms_);
+        current_.timestamp = candle_start_;
+        current_.open = current_.high = current_.low = current_.close = tick.price;
+        current_.volume = 1;
+        current_.period = static_cast<uint32_t>(period_ms_ / 1000);
+        std::strncpy(current_.symbol, "TEST", sizeof(current_.symbol));
+        has_candle_ = true;
+    }
+
+    void updateCandle(const Tick& tick) {
+        current_.high = std::max(current_.high, tick.price);
+        current_.low = std::min(current_.low, tick.price);
+        current_.close = tick.price;
+        current_.volume += 1;
+    }
+
+    uint64_t period_ms_;
+    Callback callback_;
+    uint64_t candle_start_{0};
+    Candle current_{};
+    bool has_candle_{false};
+};

--- a/_sep/testbed/mock_clock.h
+++ b/_sep/testbed/mock_clock.h
@@ -1,0 +1,11 @@
+#pragma once
+#include <cstdint>
+
+// Simple deterministic mock clock for testing
+class MockClock {
+public:
+    uint64_t now() const { return current_; }
+    void set(uint64_t t) { current_ = t; }
+private:
+    uint64_t current_{0};
+};

--- a/_sep/testbed/mock_tick_stream.h
+++ b/_sep/testbed/mock_tick_stream.h
@@ -1,0 +1,29 @@
+#pragma once
+#include <vector>
+#include <functional>
+#include <cstdint>
+#include "mock_clock.h"
+
+struct MockTick {
+    double price;
+    uint64_t timestamp; // milliseconds
+};
+
+// Deterministic tick stream that feeds ticks to a callback
+class MockTickStream {
+public:
+    using Tick = MockTick;
+    using Callback = std::function<void(const Tick&)>;
+
+    explicit MockTickStream(std::vector<Tick> ticks)
+        : ticks_(std::move(ticks)) {}
+
+    void run(MockClock& clock, Callback cb) {
+        for (const auto& t : ticks_) {
+            clock.set(t.timestamp);
+            cb(t);
+        }
+    }
+private:
+    std::vector<Tick> ticks_;
+};

--- a/_sep/testbed/simple_signal_detector.h
+++ b/_sep/testbed/simple_signal_detector.h
@@ -1,0 +1,15 @@
+#pragma once
+#include "core_types/candle_data.h"
+
+// Records if an upward closing candle occurred
+class SimpleSignalDetector {
+public:
+    void onCandle(const sep::core::CandleData& c) {
+        if (c.close > c.open) {
+            up_ = true;
+        }
+    }
+    bool upTriggered() const { return up_; }
+private:
+    bool up_{false};
+};

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_sep_test(data_pipeline_tests SOURCES data_pipeline/test_data_integrity.cpp)
 add_sep_test(pipeline_full_cycle SOURCES pipeline/test_full_cycle.cpp)
+add_sep_test(realtime_signal_test SOURCES integration/realtime_signal_test.cpp)

--- a/tests/integration/realtime_signal_test.cpp
+++ b/tests/integration/realtime_signal_test.cpp
@@ -1,0 +1,37 @@
+#include <gtest/gtest.h>
+#include <vector>
+#include "../../_sep/testbed/mock_clock.h"
+#include "../../_sep/testbed/mock_tick_stream.h"
+#include "../../_sep/testbed/candle_assembler.h"
+#include "../../_sep/testbed/simple_signal_detector.h"
+
+TEST(RealtimeSignalTest, AssemblesCandlesAndGeneratesSignal) {
+    MockClock clock;
+    std::vector<MockTick> ticks = {
+        {100.0, 0},
+        {101.0, 20000},
+        {102.0, 59000}
+    };
+    MockTickStream stream(ticks);
+    SimpleSignalDetector detector;
+    std::vector<sep::core::CandleData> candles;
+
+    CandleAssembler assembler(60000, [&](const sep::core::CandleData& c){
+        candles.push_back(c);
+        detector.onCandle(c);
+    });
+
+    stream.run(clock, [&](const MockTick& t){
+        assembler.onTick(t);
+    });
+    assembler.finalize();
+
+    ASSERT_EQ(candles.size(), 1u);
+    const auto& c = candles.front();
+    EXPECT_DOUBLE_EQ(c.open, 100.0);
+    EXPECT_DOUBLE_EQ(c.high, 102.0);
+    EXPECT_DOUBLE_EQ(c.low, 100.0);
+    EXPECT_DOUBLE_EQ(c.close, 102.0);
+    EXPECT_EQ(c.volume, 3u);
+    EXPECT_TRUE(detector.upTriggered());
+}


### PR DESCRIPTION
## Summary
- build mock clock, tick stream, candle assembler, and signal detector in `/_sep/testbed` to simulate live ticks
- add deterministic integration test assembling candles and verifying signal generation
- expose new test via CMake and unignore testbed directory

## Testing
- `g++-11 -std=c++17 tests/integration/realtime_signal_test.cpp -I./_sep/testbed -I./src -pthread -lgtest -lgtest_main -o realtime_signal_test`
- `./realtime_signal_test --gtest_color=yes`

------
https://chatgpt.com/codex/tasks/task_e_689986c8b9d0832abc696da3e4c32483