### PR TITLE
Add mock data runtime flag and detection tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -206,6 +206,10 @@ datasets/
 [._]ss[a-gi-z]
 [._]sw[a-p]
 
+# Allow internal testbed utilities
+!_sep/
+!_sep/testbed/
+
 # Emacs
 *~
 \#*\#

--- a/_sep/testbed/mock_detection.h
+++ b/_sep/testbed/mock_detection.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <cstdlib>
+#include <stdexcept>
+#include <string_view>
+
+#include "src/core_types/candle_data.h"
+
+namespace sep::testbed
+{
+
+    inline bool strict_mock_check_enabled()
+    {
+        const char* env = std::getenv("SEP_STRICT_MOCK_CHECK");
+        return env && std::string_view(env) == "1";
+    }
+
+    inline void ensure_not_mock(const sep::core::CandleData& candle)
+    {
+        if (strict_mock_check_enabled() && candle.is_mock)
+        {
+            throw std::runtime_error("Mock candle data detected in production path");
+        }
+    }
+
+}  // namespace sep::testbed

--- a/docs/mock_detection.md
+++ b/docs/mock_detection.md
@@ -1,0 +1,20 @@
+# Mock Data Detection
+
+The trading system now embeds a runtime flag in core data structures to mark whether a data object represents **real** or **mock** information.
+
+## Enabling Strict Checks
+
+Set the `SEP_STRICT_MOCK_CHECK=1` environment variable in staging or production builds to enable runtime verification. When enabled, any `CandleData` marked as mock will trigger a runtime error when passed through production code paths.
+
+Example:
+
+```bash
+export SEP_STRICT_MOCK_CHECK=1
+```
+
+Unset the variable or set it to `0` to disable the stricter checks.
+
+## Rationale
+
+These checks help ensure that simulated or placeholder data never reaches live trading logic. The default is disabled to avoid overhead during development, while staging or production environments can opt into strict validation.
+

--- a/src/common/candle_data.h
+++ b/src/common/candle_data.h
@@ -1,14 +1,17 @@
 #pragma once
 
-namespace sep::common {
+namespace sep::common
+{
 
-struct CandleData {
-    long long timestamp; // UNIX timestamp
-    double open;
-    double high;
-    double low;
-    double close;
-    long long volume;
-};
+    struct CandleData
+    {
+        long long timestamp;  // UNIX timestamp
+        double open;
+        double high;
+        double low;
+        double close;
+        long long volume;
+        bool is_mock = false;  // Runtime flag to identify mock data
+    };
 
-} // namespace sep::common
+}  // namespace sep::common

--- a/src/core_types/candle_data.h
+++ b/src/core_types/candle_data.h
@@ -5,47 +5,48 @@
 // The One True Normal Reference Frame for Financial Data Types
 // This is the canonical source of truth for all financial data structures
 
-namespace sep::core {
+namespace sep::core
+{
 
-// =============================================================================
-// CANONICAL C++ TYPES (The Normal Reference Frame)
-// =============================================================================
+    // =============================================================================
+    // CANONICAL C++ TYPES (The Normal Reference Frame)
+    // =============================================================================
 
-/// Standard OHLC candlestick data for financial markets
-struct CandleData {
-    uint64_t timestamp{0};    // UNIX timestamp in milliseconds
-    double open{0.0};         // Opening price
-    double high{0.0};         // High price
-    double low{0.0};          // Low price  
-    double close{0.0};        // Closing price
-    uint64_t volume{0};       // Trading volume
-    
-    /// Time period in seconds (e.g., 60 for 1-minute candles)
-    uint32_t period{0};
-    
-    /// Currency pair or symbol (e.g., "EUR_USD")
-    char symbol[16]{0};
-};
+    /// Standard OHLC candlestick data for financial markets
+    struct CandleData
+    {
+        uint64_t timestamp{0};  // UNIX timestamp in milliseconds
+        double open{0.0};       // Opening price
+        double high{0.0};       // High price
+        double low{0.0};        // Low price
+        double close{0.0};      // Closing price
+        uint64_t volume{0};     // Trading volume
 
-// =============================================================================
-// CUDA POD PROJECTIONS (For GPU Kernels) 
-// =============================================================================
+        /// Time period in seconds (e.g., 60 for 1-minute candles)
+        uint32_t period{0};
 
-/// POD version of CandleData for CUDA kernels - identical structure
-using CandleDataPOD = CandleData;
+        /// Runtime flag indicating whether this candle represents mock data
+        bool is_mock{false};
 
-// =============================================================================
-// MEASUREMENT FUNCTIONS (Conversions Between Reference Frames)
-// =============================================================================
+        /// Currency pair or symbol (e.g., "EUR_USD")
+        char symbol[16]{0};
+    };
 
-/// Convert canonical CandleData to POD (trivial copy for this type)
-inline void convertToPOD(const CandleData& src, CandleDataPOD& dst) {
-    dst = src;
-}
+    // =============================================================================
+    // CUDA POD PROJECTIONS (For GPU Kernels)
+    // =============================================================================
 
-/// Convert POD CandleData back to canonical (trivial copy for this type)
-inline void convertFromPOD(const CandleDataPOD& src, CandleData& dst) {
-    dst = src;
-}
+    /// POD version of CandleData for CUDA kernels - identical structure
+    using CandleDataPOD = CandleData;
 
-} // namespace sep::core
+    // =============================================================================
+    // MEASUREMENT FUNCTIONS (Conversions Between Reference Frames)
+    // =============================================================================
+
+    /// Convert canonical CandleData to POD (trivial copy for this type)
+    inline void convertToPOD(const CandleData& src, CandleDataPOD& dst) { dst = src; }
+
+    /// Convert POD CandleData back to canonical (trivial copy for this type)
+    inline void convertFromPOD(const CandleDataPOD& src, CandleData& dst) { dst = src; }
+
+}  // namespace sep::core

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_sep_test(data_pipeline_tests SOURCES data_pipeline/test_data_integrity.cpp)
 add_sep_test(pipeline_full_cycle SOURCES pipeline/test_full_cycle.cpp)
+add_sep_test(mock_detection_test SOURCES unit/mock_detection_test.cpp)

--- a/tests/unit/mock_detection_test.cpp
+++ b/tests/unit/mock_detection_test.cpp
@@ -1,0 +1,30 @@
+#include <gtest/gtest.h>
+
+#include <cstdlib>
+
+#include "../../_sep/testbed/mock_detection.h"
+
+TEST(MockDetectionTest, AllowsRealData)
+{
+    setenv("SEP_STRICT_MOCK_CHECK", "1", 1);
+    sep::core::CandleData candle;
+    EXPECT_NO_THROW(sep::testbed::ensure_not_mock(candle));
+    unsetenv("SEP_STRICT_MOCK_CHECK");
+}
+
+TEST(MockDetectionTest, RejectsMockData)
+{
+    setenv("SEP_STRICT_MOCK_CHECK", "1", 1);
+    sep::core::CandleData candle;
+    candle.is_mock = true;
+    EXPECT_THROW(sep::testbed::ensure_not_mock(candle), std::runtime_error);
+    unsetenv("SEP_STRICT_MOCK_CHECK");
+}
+
+TEST(MockDetectionTest, DisabledCheckIgnoresMock)
+{
+    unsetenv("SEP_STRICT_MOCK_CHECK");
+    sep::core::CandleData candle;
+    candle.is_mock = true;
+    EXPECT_NO_THROW(sep::testbed::ensure_not_mock(candle));
+}


### PR DESCRIPTION
## Summary
- add `is_mock` runtime flag to CandleData structures
- prototype detection helper with `SEP_STRICT_MOCK_CHECK` env toggle
- cover detection logic with unit tests and docs

## Testing
- `cmake -DBUILD_TESTING=ON ..` *(fails: NVCC not found)*

------
https://chatgpt.com/codex/tasks/task_e_689986c00b78832a9ab2271c2ccc109e