### PR TITLE
Add placeholder assertions to DSL and trading modules

### DIFF
--- a/_sep/testbed/placeholder_detection.h
+++ b/_sep/testbed/placeholder_detection.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <cstdlib>
+#include <stdexcept>
+#include <string_view>
+
+namespace sep::testbed {
+
+inline bool strict_placeholder_check_enabled() {
+    const char* env = std::getenv("SEP_STRICT_PLACEHOLDER_CHECK");
+    return env && std::string_view(env) == "1";
+}
+
+inline void ensure_not_placeholder(std::string_view value, std::string_view placeholder = "PLACEHOLDER") {
+    if (strict_placeholder_check_enabled() && value == placeholder) {
+        throw std::runtime_error("Placeholder value detected in production path");
+    }
+}
+
+} // namespace sep::testbed
+

--- a/src/dsl/compiler/compiler.cpp
+++ b/src/dsl/compiler/compiler.cpp
@@ -5,6 +5,7 @@
 #include <stdexcept>
 
 #include "stdlib/stdlib.h"
+#include "../../../_sep/testbed/placeholder_detection.h"
 
 namespace dsl::compiler {
 
@@ -47,6 +48,7 @@ std::function<void(Context&)> Compiler::compile_stream_declaration(const ast::St
 #ifdef SEP_BACKTESTING
         // Backtesting placeholder: attach mock stream data
         context.set_variable(stream.name, Value("stream_data"));
+        sep::testbed::ensure_not_placeholder("stream_data");
 #else
         throw std::runtime_error("Stream creation requires production implementation");
 #endif

--- a/src/trading/data/unified_data_manager.cpp
+++ b/src/trading/data/unified_data_manager.cpp
@@ -7,6 +7,7 @@
 #include <thread>
 
 #include "common/sep_precompiled.h"
+#include "../../../_sep/testbed/placeholder_detection.h"
 
 namespace sep::trading {
 
@@ -231,6 +232,7 @@ bool UnifiedDataManager::saveCacheFile(const std::string& filepath, const std::v
         for (const auto& item : data) {
             // TODO: Implement proper MarketData serialization
             // For now, just write placeholder
+            sep::testbed::ensure_not_placeholder("MarketData serialization placeholder");
         }
         
         return true;
@@ -253,6 +255,7 @@ std::vector<sep::connectors::MarketData> UnifiedDataManager::loadCacheFile(const
         
         // TODO: Implement proper MarketData deserialization
         // For now, return empty vector
+        sep::testbed::ensure_not_placeholder("MarketData deserialization placeholder");
         
     } catch (const std::exception& e) {
         // Return empty vector on error

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,6 +5,7 @@ add_sep_test(cuda_validation SOURCES performance/cuda_validation.cpp ../_sep/tes
 add_sep_test(trading_signal_trace SOURCES integration/test_signal_trace.cpp)
 add_sep_test(unit_data_pipeline SOURCES unit/data_pipeline_test.cpp)
 add_sep_test(mock_detection_test SOURCES unit/mock_detection_test.cpp)
+add_sep_test(placeholder_detection_test SOURCES unit/placeholder_detection_test.cpp)
 add_sep_test(accuracy_benchmark SOURCES performance/accuracy_benchmark.cpp)
 target_compile_definitions(accuracy_benchmark PRIVATE TEST_DATA_DIR="${CMAKE_SOURCE_DIR}/tests/data")
 add_sep_test(realtime_signal_test SOURCES integration/realtime_signal_test.cpp)

--- a/tests/unit/placeholder_detection_test.cpp
+++ b/tests/unit/placeholder_detection_test.cpp
@@ -1,0 +1,25 @@
+#include <gtest/gtest.h>
+
+#include <cstdlib>
+
+#include "../../_sep/testbed/placeholder_detection.h"
+
+TEST(PlaceholderDetectionTest, AllowsRealValue)
+{
+    setenv("SEP_STRICT_PLACEHOLDER_CHECK", "1", 1);
+    EXPECT_NO_THROW(sep::testbed::ensure_not_placeholder("REAL"));
+    unsetenv("SEP_STRICT_PLACEHOLDER_CHECK");
+}
+
+TEST(PlaceholderDetectionTest, RejectsPlaceholder)
+{
+    setenv("SEP_STRICT_PLACEHOLDER_CHECK", "1", 1);
+    EXPECT_THROW(sep::testbed::ensure_not_placeholder("PLACEHOLDER"), std::runtime_error);
+    unsetenv("SEP_STRICT_PLACEHOLDER_CHECK");
+}
+
+TEST(PlaceholderDetectionTest, DisabledCheckIgnoresPlaceholder)
+{
+    unsetenv("SEP_STRICT_PLACEHOLDER_CHECK");
+    EXPECT_NO_THROW(sep::testbed::ensure_not_placeholder("PLACEHOLDER"));
+}


### PR DESCRIPTION
## Summary
- add placeholder detection helper in testbed
- assert against placeholder usage in DSL stream creation
- guard trading cache serialization/deserialization with placeholder check
- test placeholder detection behavior

## Testing
- `cmake -S . -B build` *(fails: NVCC not found at /usr/bin/nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_68998d4affd8832aa2c9241c4d6baa6a