### PR TITLE
Isolate backtest stubs

### DIFF
--- a/_sep/testbed/quantum_accuracy_stub.hpp
+++ b/_sep/testbed/quantum_accuracy_stub.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <cmath>
+#include <vector>
+
+#include "../../src/connectors/oanda_connector.h"
+#include "../../src/trading/quantum_pair_trainer.hpp"
+
+namespace sep {
+namespace testbed {
+
+inline double simulate_accuracy(
+    const std::vector<sep::connectors::MarketData>& data,
+    const sep::trading::QuantumTrainingConfig& config)
+{
+    (void)data;
+    double base_accuracy = 0.58;
+    if (std::abs(config.stability_weight - 0.4) < 0.1 &&
+        std::abs(config.coherence_weight - 0.1) < 0.05 &&
+        std::abs(config.entropy_weight - 0.5) < 0.1)
+    {
+        base_accuracy += 0.05;
+    }
+    return base_accuracy;
+}
+
+} // namespace testbed
+} // namespace sep
+


### PR DESCRIPTION
## Summary
- Guard trading modules with `SEP_BACKTESTING` so testbed traces and data helpers stay out of production builds
- Move experimental accuracy computation to `_sep/testbed` and expose as `simulate_accuracy`
- Add non-testbed code paths for training data fetch and timeframe analysis in production mode

## Testing
- `./build.sh` *(fails: source directory /workspace/sep-trader/src/cli does not contain a CMakeLists.txt file)*

------
https://chatgpt.com/codex/tasks/task_e_68998d2e7890832aaf7b97d4c14d6697