### PR TITLE
docs: add patent portfolio summary

### DIFF
--- a/docs/patent_portfolio.md
+++ b/docs/patent_portfolio.md
@@ -1,0 +1,27 @@
+# SEP Engine Patent Portfolio
+
+## Invention Disclosures
+
+- **Quantum Field Harmonics (QFH) Algorithm** – interprets bit transitions as quantum states to flag NULL_STATE, FLIP, or RUPTURE conditions for early pattern collapse detection【F:docs/patent/01_QFH_INVENTION_DISCLOSURE.md†L28-L56】
+- **Quantum Bit State Analysis (QBSA) Algorithm** – compares probe indices to expectations, computing correction ratios and predicting collapse when thresholds are exceeded【F:docs/patent/02_QBSA_INVENTION_DISCLOSURE.md†L28-L63】
+- **Quantum Manifold Optimizer** – maps financial patterns onto Riemannian manifolds and samples tangent spaces for multi-objective optimization【F:docs/patent/03_QUANTUM_MANIFOLD_OPTIMIZER_INVENTION_DISCLOSURE.md†L29-L73】
+- **Pattern Evolution System** – treats patterns as evolving quantum entities with heritable coherence, stability, entropy and relationship data【F:docs/patent/04_PATTERN_EVOLUTION_INVENTION_DISCLOSURE.md†L29-L76】
+
+## Prosecution Timeline
+
+- **July 27, 2025** – Invention disclosures recorded for QFH, QBSA, Quantum Manifold Optimizer, and Pattern Evolution systems【F:docs/patent/01_QFH_INVENTION_DISCLOSURE.md†L5-L7】
+- **August 3, 2025** – Patent application filed; application #584961162ABX covers all four innovations【F:docs/patent/00_MASTER_INVENTION_SUMMARY.md†L193-L196】
+- **Present** – Application pending with ongoing prosecution monitoring and response management【F:docs/patent/00_MASTER_INVENTION_SUMMARY.md†L199-L203】
+
+## Trade Secret Summary
+
+- QFH damping relies on empirically tuned coefficients \(k_1, k_2\), which remain confidential【F:src/quantum/bitspace/qfh.cpp†L128-L133】
+- QBSA’s collapse thresholds and correction ratios are calibrated with proprietary datasets【F:src/quantum/bitspace/qbsa.cpp†L26-L31】
+- Historical path repositories driving pattern coherence and stability metrics are maintained as internal assets【F:src/quantum/bitspace/pattern_processor.cpp†L8-L20】
+
+## Implementation Highlights
+
+- `qfh.cpp` classifies adjacent bits and streams real-time state transitions, implementing the QFH disclosure【F:src/quantum/bitspace/qfh.cpp†L21-L40】【F:src/quantum/bitspace/qfh.cpp†L61-L79】
+- `qbsa.cpp` analyzes probe indices and detects collapse via adaptive thresholds, embodying the QBSA claims【F:src/quantum/bitspace/qbsa.cpp†L11-L33】【F:src/quantum/bitspace/qbsa.cpp†L36-L50】
+- `pattern_processor.cpp` derives coherence, stability, and entropy metrics from damped trajectories, aligning with the Pattern Evolution framework【F:src/quantum/bitspace/pattern_processor.cpp†L11-L40】
+


### PR DESCRIPTION
## Summary
- compile invention disclosures and prosecution timeline
- document trade secrets and map code in `src/quantum/bitspace` to patent claims

## Testing
- no tests were run; docs only change

------
https://chatgpt.com/codex/tasks/task_e_689c0f937a08832a800e3485a71e315a