### PR TITLE
Consolidate ticker optimization CUDA kernel

### DIFF
--- a/src/cuda/kernels/trading/ticker_optimization_kernel.cu
+++ b/src/cuda/kernels/trading/ticker_optimization_kernel.cu
@@ -3,62 +3,16 @@
 
 #include "common/cuda_common.h"
 #include "ticker_optimization_kernel.cuh"
+#include "quantum/trading_kernels.cuh"
 
 namespace sep::cuda::trading {
-
-namespace {
-
-/**
- * @brief CUDA kernel for ticker optimization
- * 
- * Optimizes ticker parameters for trading
- * 
- * @param ticker_data Input ticker data for optimization
- * @param optimized_parameters Output array for optimized parameters
- * @param param_count Number of parameters to optimize
- */
-__global__ void tickerOptimizationKernel(
-    const float* ticker_data,
-    float* optimized_parameters,
-    int param_count
-) {
-    int idx = blockIdx.x * blockDim.x + threadIdx.x;
-    
-    if (idx < param_count) {
-        optimized_parameters[idx] = ticker_data[idx] * 1.2f;
-    }
-}
-
-} // anonymous namespace
 
 cudaError_t launchTickerOptimizationKernel(
     const float* ticker_data,
     float* optimized_parameters,
-    int param_count
-) {
-    // Validate input parameters
-    if (!ticker_data || !optimized_parameters || param_count <= 0) {
-        return cudaErrorInvalidValue;
-    }
-
-    // Configure kernel launch parameters
-    // Use 256 threads per block for optimal occupancy
-    dim3 blockSize(256);
-    dim3 gridSize((param_count + blockSize.x - 1) / blockSize.x);
-    
-    // Launch the kernel
-    tickerOptimizationKernel<<<gridSize, blockSize>>>(
-        ticker_data, optimized_parameters, param_count
-    );
-    
-    // Check for asynchronous errors
-    cudaError_t err = cudaGetLastError();
-    if (err != cudaSuccess) {
-        return err;
-    }
-    
-    // Synchronize and check for errors
-    return cudaDeviceSynchronize();
+    int param_count) {
+    return sep::quantum::launchTickerOptimizationKernel(
+        ticker_data, optimized_parameters, param_count);
 }
 
 } // namespace sep::cuda::trading

--- a/src/quantum/trading_kernels.cu
+++ b/src/quantum/trading_kernels.cu
@@ -69,5 +69,12 @@ cudaError_t launchMultiPairProcessingKernel(
     return launchMultiPairProcessing(pair_data, processed_signals, pair_count, data_per_pair);
 }
 
+cudaError_t launchTickerOptimizationKernel(
+    const float* ticker_data,
+    float* optimized_parameters,
+    int param_count) {
+    return launchScaleBias(ticker_data, optimized_parameters, param_count, 1.2f, 0.0f);
+}
+
 }} // namespace sep::quantum
 

--- a/src/quantum/trading_kernels.cuh
+++ b/src/quantum/trading_kernels.cuh
@@ -13,5 +13,10 @@ cudaError_t launchMultiPairProcessingKernel(
     int pair_count,
     int data_per_pair);
 
+cudaError_t launchTickerOptimizationKernel(
+    const float* ticker_data,
+    float* optimized_parameters,
+    int param_count);
+
 } // namespace sep::quantum
 

--- a/src/trading/cuda/ticker_optimization_kernels.cu
+++ b/src/trading/cuda/ticker_optimization_kernels.cu
@@ -7,33 +7,18 @@
 #include <cstdint>
 #include <vector>
 
-extern "C" {
+#include "quantum/trading_kernels.cuh"
 
-__global__ void ticker_optimization_kernel(
-    const float* ticker_data,
-    float* optimized_parameters,
-    int param_count
-) {
-    int idx = blockIdx.x * blockDim.x + threadIdx.x;
-    
-    if (idx < param_count) {
-        optimized_parameters[idx] = ticker_data[idx] * 1.2f;
-    }
-}
+extern "C" {
 
 void launch_ticker_optimization(
     const float* ticker_data,
     float* optimized_parameters,
     int param_count
 ) {
-    dim3 blockSize(256);
-    dim3 gridSize((param_count + blockSize.x - 1) / blockSize.x);
-    
-    ticker_optimization_kernel<<<gridSize, blockSize>>>(
+    sep::quantum::launchTickerOptimizationKernel(
         ticker_data, optimized_parameters, param_count
     );
-    
-    cudaDeviceSynchronize();
 }
 
 } // extern "C"


### PR DESCRIPTION
## Summary
- deduplicate ticker optimization by routing all implementations to `sep::quantum::launchTickerOptimizationKernel`
- expose unified ticker optimization launch API in `src/quantum`
- simplify trading and CUDA wrappers to call the shared kernel

## Testing
- `apt-get install -y nvidia-cuda-toolkit` *(failed: required 2324 MB download)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689c19653cd4832a885a64601ec177b7