### PR TITLE
docs: add pitch claim validation matrix

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -19,3 +19,5 @@ jobs:
         run: g++-11 -std=c++17 tests/unit/data_pipeline_test.cpp -lgtest -lgtest_main -lpthread -o unit_test
       - name: Run Tests
         run: ./unit_test
+      - name: Validate pitch claim matrix
+        run: python scripts/check_validation_matrix.py

--- a/docs/proofs/validation_matrix.md
+++ b/docs/proofs/validation_matrix.md
@@ -1,0 +1,13 @@
+# Pitch Claim Validation Matrix
+
+This matrix links key claims from the investor pitch deck to concrete evidence within the repository.
+
+| Pitch Deck Claim | Supporting Evidence |
+| --- | --- |
+| Patent Application Filed (August 3, 2025) | `docs/patent/PATENT_OVERVIEW.md` |
+| Live Trading System with 60.73% accuracy | `docs/results/PERFORMANCE_METRICS.md` |
+| Enterprise Architecture with professional CLI | `src/cli/trader_cli.cpp` |
+| CUDA acceleration enables sub-ms processing | `src/apps/oanda_trader/tick_cuda_kernels.cu` |
+| Multi-timeframe analysis optimized for performance | `src/apps/oanda_trader/quantum_signal_bridge.cpp` |
+
+To add a new claim, append a row using the same format with the evidence file paths enclosed in backticks.

--- a/scripts/check_validation_matrix.py
+++ b/scripts/check_validation_matrix.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""Validate that all evidence file paths in docs/proofs/validation_matrix.md exist."""
+
+from pathlib import Path
+import re
+import sys
+
+MATRIX_PATH = Path('docs/proofs/validation_matrix.md')
+
+if not MATRIX_PATH.exists():
+    print(f"Matrix file not found: {MATRIX_PATH}")
+    sys.exit(1)
+
+missing = []
+for line in MATRIX_PATH.read_text().splitlines():
+    line = line.strip()
+    if not line.startswith('|') or line.startswith('| Pitch') or set(line) <= {'|', '-', ' '}:
+        continue
+    # Extract backticked paths from the evidence column
+    parts = [p.strip() for p in line.strip('|').split('|')]
+    if len(parts) < 2:
+        continue
+    evidence_cell = parts[1]
+    paths = re.findall(r'`([^`]+)`', evidence_cell)
+    for rel in paths:
+        if not Path(rel).exists():
+            missing.append(rel)
+
+if missing:
+    print('Missing evidence files:')
+    for m in missing:
+        print(f' - {m}')
+    sys.exit(1)
+else:
+    print('All referenced evidence files exist.')


### PR DESCRIPTION
## Summary
- document key pitch deck claims with paths to supporting evidence
- add script to verify evidence file paths and integrate into CI

## Testing
- `python scripts/check_validation_matrix.py`


------
https://chatgpt.com/codex/tasks/task_e_689c22484284832a82054c6c64c13dd6