### PR TITLE
Ensure proper signal handling in CLI

### DIFF
--- a/src/cli/trader_cli.cpp
+++ b/src/cli/trader_cli.cpp
@@ -1,6 +1,9 @@
 // Include precompiled header first for CUDA compatibility layer
 #include "../common/sep_precompiled.h"
 
+// Signal handling
+#include <csignal>
+
 // Include CUDA type system directly
 #include "../engine/internal/cuda/common/cuda_type_system.h"
 
@@ -8,7 +11,6 @@
 #include "trader_cli.hpp"
 
 // Additional system headers needed
-#include <csignal>
 #include <filesystem>
 
 // Third-party libraries
@@ -57,7 +59,7 @@ namespace sep::cli
     using ::sep::cache::WeeklyCacheManager;
 
     // Global shutdown flag, accessible within sep::cli namespace
-    volatile ::sig_atomic_t g_shutdown_requested = 0;
+    volatile sig_atomic_t g_shutdown_requested = 0;
 
     namespace
     {


### PR DESCRIPTION
## Summary
- include `<csignal>` early in trader CLI
- declare shutdown flag with `sig_atomic_t` inside `sep::cli`

## Testing
- `cmake -DSEP_USE_CUDA=OFF -S . -B build` *(passes)*
- `cmake --build build --target trader-cli` *(fails: No rule to make target "trader-cli")*


------
https://chatgpt.com/codex/tasks/task_e_689c222bc87c832a919f447ecafdb35c