### PR TITLE
Force include array header and use safe nlohmann wrapper

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ set(CMAKE_DISABLE_PRECOMPILE_HEADERS OFF)
 add_compile_definitions(
     _GLIBCXX_DEBUG_PEDANTIC=0  # Disable pedantic debug checks
     _GLIBCXX_CONCEPT_CHECKS=0  # Disable concept checks that might interfere
+    FORCE_INCLUDE_ARRAY=1
 )
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic -O3")
@@ -47,8 +48,9 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic -O3")
 # Relax two-phase name lookup for GCC 11 compatibility with nlohmann_json
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fpermissive")
 
-# Include directory for source files
+# Include directory for source files and force include array protection
 include_directories(BEFORE ${CMAKE_SOURCE_DIR}/src)
+add_compile_options(-include ${CMAKE_SOURCE_DIR}/src/array_protection.h)
 
 
 if(SEP_USE_TBB)
@@ -86,7 +88,7 @@ if(SEP_USE_CUDA)
     # Enable CUDA language and find toolkit
     enable_language(CUDA)
     find_package(CUDAToolkit REQUIRED)
-    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS}")
+    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -include ${CMAKE_SOURCE_DIR}/src/array_protection.h")
     
     message(STATUS "Found CUDAToolkit")
     message(STATUS "CUDA Libraries: ${CUDAToolkit_LIBRARY_DIR}")

--- a/_sep/testbed/cache/cache_validator.cpp
+++ b/_sep/testbed/cache/cache_validator.cpp
@@ -1,4 +1,4 @@
-#include <nlohmann/json.hpp>
+#include "nlohmann_json_safe.h"
 #include <iostream>
 #include "src/cache/cache_metadata.hpp"
 

--- a/_sep/testbed/cache_io.hpp
+++ b/_sep/testbed/cache_io.hpp
@@ -2,7 +2,7 @@
 
 #include <string>
 #include <vector>
-#include <nlohmann/json.hpp>
+#include "nlohmann_json_safe.h"
 
 namespace sep::testbed {
 

--- a/_sep/testbed/metadata_persistence.cpp
+++ b/_sep/testbed/metadata_persistence.cpp
@@ -1,4 +1,4 @@
-#include <nlohmann/json.hpp>
+#include "nlohmann_json_safe.h"
 #include <fstream>
 #include <iostream>
 #include "../src/cache/cache_metadata.hpp"

--- a/_sep/testbed/oanda_data_pipeline.cpp
+++ b/_sep/testbed/oanda_data_pipeline.cpp
@@ -1,4 +1,4 @@
-#include <nlohmann/json.hpp>
+#include "nlohmann_json_safe.h"
 #include <fstream>
 #include <vector>
 #include <string>

--- a/_sep/testbed/tests/signal_pipeline_test.cpp
+++ b/_sep/testbed/tests/signal_pipeline_test.cpp
@@ -1,7 +1,7 @@
 #define SEP_ENABLE_TRACE
 #include "../trace.hpp"
 #include "../../src/trading/signal_pipeline.hpp"
-#include <nlohmann/json.hpp>
+#include "nlohmann_json_safe.h"
 #include <fstream>
 #include <vector>
 #include <string>

--- a/src/apps/oanda_trader/market_regime_adaptive.cpp
+++ b/src/apps/oanda_trader/market_regime_adaptive.cpp
@@ -1,3 +1,4 @@
+#include "nlohmann_json_safe.h"
 #include "market_regime_adaptive.hpp"
 
 #include <fmt/format.h>

--- a/src/apps/oanda_trader/oanda_trader_app.cpp
+++ b/src/apps/oanda_trader/oanda_trader_app.cpp
@@ -1,3 +1,4 @@
+#include "nlohmann_json_safe.h"
 #include "oanda_trader_app.hpp"
 
 #include "common/sep_precompiled.h"

--- a/src/array_protection.h
+++ b/src/array_protection.h
@@ -1,0 +1,6 @@
+#ifndef SEP_ARRAY_PROTECTION_H
+#define SEP_ARRAY_PROTECTION_H
+
+#include <array>
+
+#endif // SEP_ARRAY_PROTECTION_H

--- a/src/common/json_wrapper.hpp
+++ b/src/common/json_wrapper.hpp
@@ -13,7 +13,7 @@
 #include <array>
 
 // Now include the actual json library
-#include <nlohmann/json.hpp>
+#include "nlohmann_json_safe.h"
 
 // Re-export the nlohmann namespace for convenience
 namespace sep {

--- a/src/connectors/oanda_connector.h
+++ b/src/connectors/oanda_connector.h
@@ -15,7 +15,7 @@
 
 #include "common/financial_data_types.h"
 #include "engine/internal/standard_includes.h"
-#include <nlohmann/json.hpp>
+#include "nlohmann_json_safe.h"
 
 namespace sep {
 namespace connectors {

--- a/src/connectors/qdrant_connector.cpp
+++ b/src/connectors/qdrant_connector.cpp
@@ -1,3 +1,4 @@
+#include "nlohmann_json_safe.h"
 #include "qdrant_connector.h"
 #include <curl/curl.h>
 #include <sstream>

--- a/src/connectors/qdrant_connector.h
+++ b/src/connectors/qdrant_connector.h
@@ -4,7 +4,7 @@
 #include <string>
 #include <vector>
 #include <cstdint>
-#include <nlohmann/json.hpp>
+#include "nlohmann_json_safe.h"
 
 namespace sep {
 namespace connectors {

--- a/src/connectors/test_qdrant.cpp
+++ b/src/connectors/test_qdrant.cpp
@@ -1,3 +1,4 @@
+#include "nlohmann_json_safe.h"
 #include "qdrant_connector.h"
 #include <iostream>
 #include <vector>

--- a/src/dsl/ast/serializer.h
+++ b/src/dsl/ast/serializer.h
@@ -1,4 +1,4 @@
-#include <nlohmann/json.hpp>
+#include "nlohmann_json_safe.h"
 #pragma once
 #include <array>
 #include <memory>

--- a/src/engine/internal/json_config.h
+++ b/src/engine/internal/json_config.h
@@ -1,4 +1,4 @@
-#include <nlohmann/json.hpp>
+#include "nlohmann_json_safe.h"
 #pragma once
 
 // Disable nlohmann::json's internal assertions to avoid conflicts.

--- a/src/nlohmann_json_safe.h
+++ b/src/nlohmann_json_safe.h
@@ -1,28 +1,14 @@
-#pragma once
+#ifndef NLOHMANN_JSON_SAFE_INCLUDED
+#define NLOHMANN_JSON_SAFE_INCLUDED
 
-// Include required standard headers first
-#include <array>
+#include <cstddef>
 #include <cstdint>
+#include <algorithm>
+#include <array>
+#include <memory>
 #include <string>
 #include <vector>
-#include <map>
-#include <unordered_map>
-#include <utility>
-#include <algorithm>
-#include <initializer_list>
-#include <memory>
 
-// Disable exceptions for performance and to avoid issues with CUDA
-#define NLOHMANN_JSON_NOEXCEPTION 1
-
-// Include the nlohmann/json header
 #include <nlohmann/json.hpp>
 
-// Export commonly used types
-namespace sep {
-namespace json {
-    using json = nlohmann::json;
-    using json_ref = nlohmann::json&;
-    using const_json_ref = const nlohmann::json&;
-} // namespace json
-} // namespace sep
+#endif // NLOHMANN_JSON_SAFE_INCLUDED

--- a/src/quantum/pattern_evolution.h
+++ b/src/quantum/pattern_evolution.h
@@ -1,4 +1,4 @@
-#include <nlohmann/json.hpp>
+#include "nlohmann_json_safe.h"
 #pragma once
 
 #include <array>

--- a/src/quantum/resource_predictor.h
+++ b/src/quantum/resource_predictor.h
@@ -1,4 +1,4 @@
-#include <nlohmann/json.hpp>
+#include "nlohmann_json_safe.h"
 #ifndef SEP_CONTEXT_RESOURCE_PREDICTOR_H
 #define SEP_CONTEXT_RESOURCE_PREDICTOR_H
 

--- a/src/quantum/types_serialization.h
+++ b/src/quantum/types_serialization.h
@@ -1,4 +1,4 @@
-#include <nlohmann/json.hpp>
+#include "nlohmann_json_safe.h"
 #pragma once
 
 #include <array>

--- a/src/training/training_coordinator.cpp
+++ b/src/training/training_coordinator.cpp
@@ -1,3 +1,4 @@
+#include "nlohmann_json_safe.h"
 // SEP Professional Training Coordinator Implementation
 // Coordinates local CUDA training with remote trading deployment
 

--- a/test_cuda_build.cu
+++ b/test_cuda_build.cu
@@ -1,7 +1,7 @@
 // Simple test to verify CUDA+JSON compatibility
 
 #include "common/sep_precompiled.h"
-#include <nlohmann/json.hpp>
+#include "nlohmann_json_safe.h"
 
 int main() {
     nlohmann::json j;

--- a/tests/data_pipeline/test_data_integrity.cpp
+++ b/tests/data_pipeline/test_data_integrity.cpp
@@ -3,7 +3,7 @@
 #include "connectors/oanda_connector.h"
 #include "dsl/stdlib/core_primitives.h"
 #include "cache/cache_validator.hpp"
-#include <nlohmann/json.hpp>
+#include "nlohmann_json_safe.h"
 #include <fstream>
 #include <filesystem>
 #include <cstdlib>

--- a/tests/pipeline/test_full_cycle.cpp
+++ b/tests/pipeline/test_full_cycle.cpp
@@ -2,7 +2,7 @@
 
 #include <chrono>
 #include <fstream>
-#include <nlohmann/json.hpp>
+#include "nlohmann_json_safe.h"
 #include <vector>
 
 #include "apps/oanda_trader/candle_types.h"

--- a/tests/unit/data_pipeline_test.cpp
+++ b/tests/unit/data_pipeline_test.cpp
@@ -1,5 +1,5 @@
 #include <gtest/gtest.h>
-#include <nlohmann/json.hpp>
+#include "nlohmann_json_safe.h"
 #include <fstream>
 #include <vector>
 #include <string>


### PR DESCRIPTION
## Summary
- Force-include `array_protection.h` across all targets via global CMake options and CUDA flags
- Align `nlohmann_json_safe.h` with documented snippet and replace direct `nlohmann/json.hpp` includes
- Add minimal `array_protection.h` wrapper to guarantee `std::array` availability

## Testing
- `./build.sh --no-docker` *(fails: cuda_runtime.h missing; hiredis/hiredis.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_689c2225773c832aa1d69a7e1dccaf35