### PR TITLE
refactor: consolidate result types

### DIFF
--- a/src/core/result_types.h
+++ b/src/core/result_types.h
@@ -176,9 +176,3 @@ using Result = sep::Result<T>;
 }
 
 } // namespace sep
-
-// Global namespace alias for backward compatibility
-namespace util {
-template <typename T, typename E>
-using Result = ::sep::Result<T>;
-}

--- a/src/core/ticker_pattern_analyzer.cpp
+++ b/src/core/ticker_pattern_analyzer.cpp
@@ -14,51 +14,6 @@
 #include <iomanip>
 #include <algorithm>
 
-// Forward declarations to avoid problematic header includes
-namespace sep {
-    struct Error {
-        enum class Code {
-            Success, InvalidArgument, NotFound, ProcessingError, InternalError,
-            NotInitialized, CudaError, UnknownError, ResourceUnavailable, 
-            OperationFailed, NotImplemented, AlreadyExists, Internal = InternalError
-        };
-        Code code = Code::Success;
-        std::string message;
-        std::string location;
-        Error() = default;
-        Error(Code c, const std::string& msg = "") : code(c), message(msg) {}
-    };
-    
-    template<typename T>
-    class Result {
-    private:
-        std::variant<T, Error> data_;
-    public:
-        Result(const T& value) : data_(value) {}
-        Result(T&& value) : data_(std::move(value)) {}
-        Result(const Error& error) : data_(error) {}
-        Result(Error&& error) : data_(std::move(error)) {}
-        bool isSuccess() const { return std::holds_alternative<T>(data_); }
-        bool isError() const { return std::holds_alternative<Error>(data_); }
-        const T& value() const { return std::get<T>(data_); }
-        T& value() { return std::get<T>(data_); }
-        const Error& error() const { return std::get<Error>(data_); }
-        Error& error() { return std::get<Error>(data_); }
-    };
-    
-    template<typename T>
-    Result<T> makeSuccess(T&& value) { return Result<T>(std::forward<T>(value)); }
-    
-    template<typename T>  
-    Result<T> makeError(const Error& error) { return Result<T>(error); }
-
-    namespace engine {
-        enum class Timeframe { M1, M5, M15, H1, H4, D1 };
-    }
-}
-
-// Include only the specific variant header needed for Result
-#include <variant>
 
 namespace sep::engine {
 


### PR DESCRIPTION
## Summary
- remove local Error/Result struct definitions from ticker_pattern_analyzer.cpp
- drop duplicate global util::Result alias in result_types.h

## Testing
- `cppcheck --enable=warning --language=c++ src/core/ticker_pattern_analyzer.cpp src/core/result_types.h`


------
https://chatgpt.com/codex/tasks/task_e_68a6f6741740832a84133f645dfe3dfb