### PR TITLE
Remove duplicate util::Result alias

### DIFF
--- a/src/core/result_types.h
+++ b/src/core/result_types.h
@@ -168,17 +168,11 @@ namespace result {
     constexpr SEPResult NOT_FOUND = SEPResult::NOT_FOUND;
 }
 
-// Add util namespace alias for backward compatibility
-namespace util {
-    // Two-parameter version matches ticker_pattern_analyzer usage
-template <typename T, typename E>
-using Result = sep::Result<T>;
-}
-
 } // namespace sep
 
-// Global namespace alias for backward compatibility
+// util namespace alias for backward compatibility
 namespace util {
-template <typename T, typename E>
-using Result = ::sep::Result<T>;
+    // Two-parameter version matches ticker_pattern_analyzer usage
+    template <typename T, typename E>
+    using Result = ::sep::Result<T>;
 }


### PR DESCRIPTION
## Summary
- streamline result type aliases by retaining only the global `util::Result`

## Testing
- `rg "util::Result" -n`

------
https://chatgpt.com/codex/tasks/task_e_68a6f69db9d4832a9a286777c867e4b8