### PR TITLE
refactor: centralize timeframe enum

### DIFF
--- a/src/core/RemoteDataManager.h
+++ b/src/core/RemoteDataManager.h
@@ -5,6 +5,7 @@
 #include <memory>
 #include <pqxx/pqxx>
 #include <hiredis/hiredis.h>
+#include "core/timeframe.h"
 
 namespace sep {
 namespace trading {
@@ -24,9 +25,7 @@ struct TrainingData {
     std::string timestamp;
 };
 
-enum class Timeframe {
-    M1, M5, M15, M30, H1, H4, D1
-};
+using ::sep::Timeframe;
 
 class RemoteDataManager {
 public:

--- a/src/core/ticker_pattern_analyzer.cpp
+++ b/src/core/ticker_pattern_analyzer.cpp
@@ -52,9 +52,6 @@ namespace sep {
     template<typename T>  
     Result<T> makeError(const Error& error) { return Result<T>(error); }
 
-    namespace engine {
-        enum class Timeframe { M1, M5, M15, H1, H4, D1 };
-    }
 }
 
 // Include only the specific variant header needed for Result
@@ -64,11 +61,14 @@ namespace sep::engine {
 
 // ---------- Helper functions ----------
 
+using ::sep::Timeframe;
+
 std::string SepEngine::timeframe_str(Timeframe tf) {
     switch (tf) {
         case Timeframe::M1: return std::string("M1");
         case Timeframe::M5: return std::string("M5");
         case Timeframe::M15: return std::string("M15");
+        case Timeframe::M30: return std::string("M30");
         case Timeframe::H1: return std::string("H1");
         case Timeframe::H4: return std::string("H4");
         case Timeframe::D1: return std::string("D1");

--- a/src/core/ticker_pattern_analyzer.hpp
+++ b/src/core/ticker_pattern_analyzer.hpp
@@ -28,12 +28,13 @@
 #include "core/qfh.h"                         // if you keep legacy QFH/QBSA interop
 #include "core/quantum_manifold_optimizer.h"  // GAO impl lives here or new header
 #include "core/result_types.h"                // sep::Result<T>
+#include "core/timeframe.h"
 
 namespace sep::engine {
 
 // ---------- Strong enums / IDs ----------
 
-enum class Timeframe : uint8_t { M1, M5, M15, H1, H4, D1 };
+using ::sep::Timeframe;
 enum class Side : uint8_t { Buy, Sell, Flat };
 enum class Strength : uint8_t { None, Weak, Moderate, Strong, VeryStrong };
 

--- a/src/core/timeframe.h
+++ b/src/core/timeframe.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <cstdint>
+
+namespace sep {
+
+enum class Timeframe : uint8_t {
+    M1,
+    M5,
+    M15,
+    M30,
+    H1,
+    H4,
+    D1
+};
+
+} // namespace sep
+


### PR DESCRIPTION
## Summary
- centralize the Timeframe enum in a new `src/core/timeframe.h` header
- update core components to include the new header and drop duplicate enums
- extend `timeframe_str` to recognize the `M30` timeframe

## Testing
- `g++ -std=c++20 -I./src _sep/testbed/timeframe_compile_test.cpp -c -o _sep/testbed/timeframe_compile_test.o`
- `g++ -std=c++20 -I./src src/core/ticker_pattern_analyzer.cpp -c -o /tmp/ticker_pattern_analyzer.o` *(fails: cuda_runtime.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f68c73d4832abfaac68713f980e7