### PR TITLE
refactor: replace forward decls and fix include order

### DIFF
--- a/src/core/batch_processor.cpp
+++ b/src/core/batch_processor.cpp
@@ -1,5 +1,3 @@
-#include "batch_processor.h"
-
 #include <algorithm>
 #include <chrono>
 #include <cstdlib>
@@ -7,6 +5,7 @@
 #include <mutex>
 #include <sstream>
 
+#include "batch_processor.h"
 #include "core/facade.h"
 
 namespace sep::engine::batch {

--- a/src/core/cache_validator.cpp
+++ b/src/core/cache_validator.cpp
@@ -1,13 +1,14 @@
-#include "core/cache_validator.hpp"
-#include <stdexcept>
-#include <sstream>
-#include <fstream>
-#include <vector>
-#include <memory>
-#include <filesystem>
-#include <sys/stat.h>
-#include <ctime>
 #include <chrono>
+#include <ctime>
+#include <filesystem>
+#include <fstream>
+#include <memory>
+#include <sstream>
+#include <stdexcept>
+#include <sys/stat.h>
+#include <vector>
+
+#include "core/cache_validator.hpp"
 #include "util/nlohmann_json_safe.h"
 
 namespace sep::cache {

--- a/src/core/coherence_manager.cpp
+++ b/src/core/coherence_manager.cpp
@@ -1,27 +1,23 @@
-#include "coherence_manager.h"
-
-#include <cuda_runtime.h>
-
-#include "core/sep_precompiled.h"
-#include "core/cuda_types.hpp"
-
-#ifdef __CUDACC__
-#include <cuda_runtime.h>
-
-#endif
-#include <tbb/concurrent_hash_map.h>
-#include <tbb/parallel_for.h>
-
 #include <algorithm>
 #include <array>
 #include <atomic>
 #include <cmath>
+#include <cuda_runtime.h>
 #include <glm/vec4.hpp>
 #include <memory>
 #include <numeric>
 #include <string>
+#include <tbb/concurrent_hash_map.h>
+#include <tbb/parallel_for.h>
 #include <vector>
 
+#ifdef __CUDACC__
+#include <cuda_runtime.h>
+#endif
+
+#include "coherence_manager.h"
+#include "core/sep_precompiled.h"
+#include "core/cuda_types.hpp"
 #include "core/core.h"
 #include "cuda.h"
 #include "core/cuda_helpers.h"

--- a/src/core/compression.cpp
+++ b/src/core/compression.cpp
@@ -1,9 +1,9 @@
-#include "compression.h"
-
-#include "core/standard_includes.h"
 #include <algorithm>
 #include <cmath>
 #include <unordered_map>
+
+#include "compression.h"
+#include "core/standard_includes.h"
 
 namespace sep {
 namespace core {

--- a/src/core/config_watcher.cpp
+++ b/src/core/config_watcher.cpp
@@ -1,8 +1,9 @@
-#include "config_watcher.hpp"
-#include <iostream>
-#include <fstream>
 #include <algorithm>
 #include <filesystem>
+#include <fstream>
+#include <iostream>
+
+#include "config_watcher.hpp"
 
 namespace sep::config {
 

--- a/src/core/currency_quantum_processor.cpp
+++ b/src/core/currency_quantum_processor.cpp
@@ -1,6 +1,7 @@
+#include <vector>
+
 #include "currency_quantum_processor.hpp"
 #include "core/trace.hpp"
-#include <vector>
 
 namespace sep::trading {
 

--- a/src/core/dag_graph.cpp
+++ b/src/core/dag_graph.cpp
@@ -1,8 +1,8 @@
-#include "core/dag_graph.h"
-
 // Standard library includes
 #include <algorithm>
 #include <vector>
+
+#include "core/dag_graph.h"
 
 namespace sep {
 namespace dag {

--- a/src/core/pattern_cache.cpp
+++ b/src/core/pattern_cache.cpp
@@ -1,8 +1,9 @@
+#include <algorithm>
+#include <iostream>
+#include <sstream>
+
 #include "pattern_cache.h"
 #include "core/result_types.h"
-#include <algorithm>
-#include <sstream>
-#include <iostream>
 
 namespace sep::engine::cache {
 

--- a/src/core/ticker_pattern_analyzer.cpp
+++ b/src/core/ticker_pattern_analyzer.cpp
@@ -1,64 +1,18 @@
-#include "core/ticker_pattern_analyzer.hpp"
-
-// Only include absolutely essential headers to avoid namespace pollution
-#include <string>
-#include <sstream>
-#include <chrono>
-#include <thread>
-#include <mutex>
+#include <algorithm>
 #include <atomic>
+#include <chrono>
+#include <iomanip>
 #include <memory>
-#include <vector>
+#include <mutex>
 #include <optional>
 #include <random>
-#include <iomanip>
-#include <algorithm>
+#include <sstream>
+#include <string>
+#include <thread>
+#include <vector>
 
-// Forward declarations to avoid problematic header includes
-namespace sep {
-    struct Error {
-        enum class Code {
-            Success, InvalidArgument, NotFound, ProcessingError, InternalError,
-            NotInitialized, CudaError, UnknownError, ResourceUnavailable, 
-            OperationFailed, NotImplemented, AlreadyExists, Internal = InternalError
-        };
-        Code code = Code::Success;
-        std::string message;
-        std::string location;
-        Error() = default;
-        Error(Code c, const std::string& msg = "") : code(c), message(msg) {}
-    };
-    
-    template<typename T>
-    class Result {
-    private:
-        std::variant<T, Error> data_;
-    public:
-        Result(const T& value) : data_(value) {}
-        Result(T&& value) : data_(std::move(value)) {}
-        Result(const Error& error) : data_(error) {}
-        Result(Error&& error) : data_(std::move(error)) {}
-        bool isSuccess() const { return std::holds_alternative<T>(data_); }
-        bool isError() const { return std::holds_alternative<Error>(data_); }
-        const T& value() const { return std::get<T>(data_); }
-        T& value() { return std::get<T>(data_); }
-        const Error& error() const { return std::get<Error>(data_); }
-        Error& error() { return std::get<Error>(data_); }
-    };
-    
-    template<typename T>
-    Result<T> makeSuccess(T&& value) { return Result<T>(std::forward<T>(value)); }
-    
-    template<typename T>  
-    Result<T> makeError(const Error& error) { return Result<T>(error); }
-
-    namespace engine {
-        enum class Timeframe { M1, M5, M15, H1, H4, D1 };
-    }
-}
-
-// Include only the specific variant header needed for Result
-#include <variant>
+#include "core/ticker_pattern_analyzer.hpp"
+#include "core/result_types.h"
 
 namespace sep::engine {
 


### PR DESCRIPTION
## Summary
- replace local Error/Result definitions with canonical header in ticker_pattern_analyzer.cpp
- normalize include ordering across core modules so standard headers precede project headers

## Testing
- `g++ -std=c++20 -fsyntax-only -Isrc -I. src/core/ticker_pattern_analyzer.cpp` *(fails: cuda_runtime.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f6a8b0c0832a91424f48f83de67d