### PR TITLE
Add macro pollution debugging and protection

### DIFF
--- a/src/app/cli_main.cpp
+++ b/src/app/cli_main.cpp
@@ -1,6 +1,9 @@
 // SEP Professional Training CLI
 // Advanced interface for CUDA training coordination and remote sync
 
+// Guard against standard symbol redefinition
+#include "../common/namespace_protection.hpp"
+
 // Use C-style I/O to bypass macro pollution
 #include <cstdio>
 #include <vector>
@@ -11,16 +14,8 @@
 #include <random>
 #include <cstring>
 
-// Protect against macro pollution before including project headers
-#ifdef cout
-#undef cout
-#endif
-#ifdef string
-#undef string
-#endif
-#ifdef std
-#undef std
-#endif
+// Restore any previous macro definitions
+#include "../common/namespace_protection.hpp"
 
 void printHeader() {
     printf("\n");

--- a/src/common/namespace_protection.hpp
+++ b/src/common/namespace_protection.hpp
@@ -1,0 +1,59 @@
+#pragma once
+
+// Protect standard library names from macro pollution.
+// Include this header before and after third-party headers
+// that may redefine standard symbols. The first inclusion
+// pushes and undefines macros; the second inclusion restores them.
+
+#ifndef SEP_NAMESPACE_PROTECTION_ACTIVE
+#define SEP_NAMESPACE_PROTECTION_ACTIVE
+
+#ifdef string
+#pragma push_macro("string")
+#undef string
+#define SEP_NS_PROTECT_STRING
+#endif
+
+#ifdef cout
+#pragma push_macro("cout")
+#undef cout
+#define SEP_NS_PROTECT_COUT
+#endif
+
+#ifdef ostream
+#pragma push_macro("ostream")
+#undef ostream
+#define SEP_NS_PROTECT_OSTREAM
+#endif
+
+#ifdef std
+#pragma push_macro("std")
+#undef std
+#define SEP_NS_PROTECT_STD
+#endif
+
+#else // SEP_NAMESPACE_PROTECTION_ACTIVE
+
+#ifdef SEP_NS_PROTECT_STRING
+#pragma pop_macro("string")
+#undef SEP_NS_PROTECT_STRING
+#endif
+
+#ifdef SEP_NS_PROTECT_COUT
+#pragma pop_macro("cout")
+#undef SEP_NS_PROTECT_COUT
+#endif
+
+#ifdef SEP_NS_PROTECT_OSTREAM
+#pragma pop_macro("ostream")
+#undef SEP_NS_PROTECT_OSTREAM
+#endif
+
+#ifdef SEP_NS_PROTECT_STD
+#pragma pop_macro("std")
+#undef SEP_NS_PROTECT_STD
+#endif
+
+#undef SEP_NAMESPACE_PROTECTION_ACTIVE
+#endif // SEP_NAMESPACE_PROTECTION_ACTIVE
+

--- a/tools/debug_macro_pollution.sh
+++ b/tools/debug_macro_pollution.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Trace macro definitions and header includes to identify std namespace pollution.
+set -euo pipefail
+
+SRC=${1:-src/app/cli_main.cpp}
+TMP_DIR=$(mktemp -d)
+
+echo "[macro] generating macro dump for $SRC"
+gcc -E -dM "$SRC" > "$TMP_DIR/macros.txt"
+rg -n "#define\s+(std|string|cout|ostream)\b" "$TMP_DIR/macros.txt" || echo "no std macro pollution detected"
+
+echo "[include] generating include trace"
+gcc -E -H "$SRC" > /dev/null 2> "$TMP_DIR/include_trace.txt"
+
+echo "macro dump: $TMP_DIR/macros.txt"
+echo "include trace: $TMP_DIR/include_trace.txt"


### PR DESCRIPTION
## Summary
- add namespace_protection header to push/undef/pop macros that clash with standard names
- provide debug_macro_pollution script for tracing macros and include chains
- integrate namespace protection into CLI main

## Testing
- `./tools/debug_macro_pollution.sh src/app/cli_main.cpp`
- `g++ -std=c++17 -fsyntax-only src/app/cli_main.cpp && echo OK`


------
https://chatgpt.com/codex/tasks/task_e_68a6fe894a94832a8dec2e69ce2f093c