### PR TITLE
feat: add CLI bridge and command execution endpoint

### DIFF
--- a/scripts/cli_bridge.py
+++ b/scripts/cli_bridge.py
@@ -1,0 +1,35 @@
+import json
+import os
+import subprocess
+from typing import List, Dict, Any
+
+
+class CLIBridge:
+    """Wrapper around the trader CLI."""
+
+    def __init__(self, executable: str | None = None) -> None:
+        if executable is None:
+            repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+            executable = os.path.join(repo_root, 'build', 'src', 'cli', 'trader-cli')
+        self.executable = executable
+
+    def run(self, args: List[str]) -> str:
+        """Execute trader-cli with provided arguments.
+
+        Parameters
+        ----------
+        args: List[str]
+            Arguments to pass to trader-cli.
+
+        Returns
+        -------
+        str
+            JSON string containing stdout, stderr, and exit status.
+        """
+        result = subprocess.run([self.executable, *args], capture_output=True, text=True)
+        output: Dict[str, Any] = {
+            'stdout': result.stdout,
+            'stderr': result.stderr,
+            'status': result.returncode,
+        }
+        return json.dumps(output)


### PR DESCRIPTION
## Summary
- add CLIBridge for running trader-cli and capturing output as JSON
- extend trading service with `/api/commands/execute` endpoint

## Testing
- `python -m py_compile scripts/cli_bridge.py scripts/trading_service.py`
- `ctest` *(fails: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_68a789b53f14832a8187cc398a01be98