### PR TITLE
Add API client and WebSocket hooks in testbed

### DIFF
--- a/_sep/testbed/web/QuantumDiagnostics.jsx
+++ b/_sep/testbed/web/QuantumDiagnostics.jsx
@@ -1,0 +1,19 @@
+import React, { useState } from 'react';
+import useWebSocket from './useWebSocket';
+
+export default function QuantumDiagnostics() {
+  const [metrics, setMetrics] = useState([]);
+
+  useWebSocket((metric) => {
+    setMetrics((prev) => [...prev, metric]);
+  });
+
+  const latest = metrics[metrics.length - 1];
+
+  return (
+    <div>
+      <h3>Quantum Diagnostics</h3>
+      {latest ? <pre>{JSON.stringify(latest, null, 2)}</pre> : <p>No metrics received.</p>}
+    </div>
+  );
+}

--- a/_sep/testbed/web/useApiClient.js
+++ b/_sep/testbed/web/useApiClient.js
@@ -1,0 +1,33 @@
+import { useCallback } from 'react';
+
+const API_URL = process.env.REACT_APP_API_URL || '';
+
+export default function useApiClient() {
+  const fetchJson = useCallback(async (path, options = {}) => {
+    const response = await fetch(`${API_URL}${path}`, options);
+    if (!response.ok) {
+      throw new Error(`Request failed with ${response.status}`);
+    }
+    return response.json();
+  }, []);
+
+  const getStatus = useCallback(() => fetchJson('/api/status'), [fetchJson]);
+  const getPairs = useCallback(() => fetchJson('/api/pairs'), [fetchJson]);
+  const getPerformanceHistory = useCallback(() => fetchJson('/api/performance/history'), [fetchJson]);
+  const executeCommand = useCallback(
+    (command) =>
+      fetchJson('/api/commands/execute', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ command }),
+      }),
+    [fetchJson]
+  );
+
+  return {
+    getStatus,
+    getPairs,
+    getPerformanceHistory,
+    executeCommand,
+  };
+}

--- a/_sep/testbed/web/useWebSocket.js
+++ b/_sep/testbed/web/useWebSocket.js
@@ -1,0 +1,27 @@
+import { useEffect, useRef } from 'react';
+
+export default function useWebSocket(onMetric) {
+  const socketRef = useRef(null);
+
+  useEffect(() => {
+    const base = process.env.REACT_APP_API_URL || '';
+    const wsUrl = `${base}`.replace(/^http/, 'ws') + '/ws';
+    const socket = new WebSocket(wsUrl);
+    socketRef.current = socket;
+
+    socket.onmessage = (event) => {
+      try {
+        const data = JSON.parse(event.data);
+        onMetric && onMetric(data);
+      } catch (_) {
+        // ignore parse errors
+      }
+    };
+
+    return () => {
+      socket.close();
+    };
+  }, [onMetric]);
+
+  return socketRef;
+}


### PR DESCRIPTION
## Summary
- Add React API client hook configured by `REACT_APP_API_URL` with helpers for status, pairs, performance, and command execution.
- Introduce WebSocket hook and sample QuantumDiagnostics component to surface live metrics.

## Testing
- `ctest` *(fails: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_68a789bb0e30832a8adf740182e7c536