### PR TITLE
Add websocket metrics broadcast

### DIFF
--- a/scripts/trading_service.py
+++ b/scripts/trading_service.py
@@ -19,6 +19,7 @@ import signal
 sys.path.append(os.path.dirname(__file__))
 from trading.risk import RiskManager, RiskLimits  # noqa: E402
 from oanda_connector import OandaConnector  # noqa: E402
+from websocket_service import start_websocket_server  # noqa: E402
 
 # Setup logging with environment-appropriate paths
 def setup_logging():
@@ -308,6 +309,11 @@ if __name__ == "__main__":
     server_thread.start()
 
     logger.info(f"🌐 API server started on port {port}")
+
+    # Start WebSocket metrics server
+    ws_port = int(os.environ.get('WS_PORT', 8765))
+    start_websocket_server(ws_port)
+    logger.info(f"📡 WebSocket server started on port {ws_port}")
 
     try:
         # Start trading service (blocking)

--- a/scripts/websocket_service.py
+++ b/scripts/websocket_service.py
@@ -1,0 +1,61 @@
+import asyncio
+import json
+import logging
+import os
+import threading
+from typing import Set
+
+import websockets
+
+logger = logging.getLogger(__name__)
+
+CLIENTS: Set[websockets.WebSocketServerProtocol] = set()
+METRICS_PATH = os.environ.get("METRICS_PATH", "/app/data/quantum_metrics.json")
+
+async def _load_metrics() -> dict:
+    """Load quantum metrics from shared JSON source."""
+    def _read_file():
+        if os.path.exists(METRICS_PATH):
+            with open(METRICS_PATH, "r", encoding="utf-8") as f:
+                return json.load(f)
+        return {}
+    try:
+        return await asyncio.to_thread(_read_file)
+    except Exception as exc:
+        logger.error(f"Failed to read metrics: {exc}")
+        return {}
+
+async def _broadcast_loop(interval: float = 5.0) -> None:
+    """Periodically broadcast metrics to connected clients."""
+    while True:
+        metrics = await _load_metrics()
+        if CLIENTS and metrics:
+            message = json.dumps(metrics)
+            await asyncio.gather(*(ws.send(message) for ws in list(CLIENTS)))
+        await asyncio.sleep(interval)
+
+async def _ws_handler(websocket: websockets.WebSocketServerProtocol, path: str) -> None:
+    if path != "/ws":
+        await websocket.close()
+        return
+    CLIENTS.add(websocket)
+    try:
+        await websocket.wait_closed()
+    finally:
+        CLIENTS.remove(websocket)
+
+async def _run_server(port: int) -> None:
+    async with websockets.serve(_ws_handler, "0.0.0.0", port):
+        await _broadcast_loop()
+
+def start_websocket_server(port: int = 8765) -> threading.Thread:
+    """Start the websocket server in a background thread."""
+    loop = asyncio.new_event_loop()
+
+    def _run():
+        asyncio.set_event_loop(loop)
+        loop.run_until_complete(_run_server(port))
+
+    thread = threading.Thread(target=_run, daemon=True)
+    thread.start()
+    return thread


### PR DESCRIPTION
## Summary
- introduce websocket service exposing `/ws` that broadcasts quantum metrics
- launch websocket server alongside HTTP server in trading service

## Testing
- `python -m py_compile scripts/websocket_service.py scripts/trading_service.py`
- `ctest` *(fails: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_68a789b74cd4832aba043bb7e27ce7da