### PR TITLE
Remove placeholder integrations for Redis and frontend API

### DIFF
--- a/duplicate_implementations_report.md
+++ b/duplicate_implementations_report.md
@@ -8,7 +8,6 @@ This document tracks outstanding code quality concerns in the SEP Engine codebas
 ### Hardcoded Values
 - `src/io/oanda_connector.cpp` - Hardcoded URLs and magic numbers.
 - `src/cuda/kernels.cu` - Hardcoded block and grid sizes.
-- `frontend/src/services/api.ts` - Default API base URL.
 
 ### Inconsistent Implementations
 - `src/app/dsl_main.cpp` and `src/app/oanda_trader_main.cpp` use different error handling mechanisms.
@@ -25,6 +24,8 @@ This document tracks outstanding code quality concerns in the SEP Engine codebas
 - Placeholder training CLI and duplicate MemoryTierService implementation removed (`src/app/cli_main.cpp`, `src/app/MemoryTierService.*`).
 - Duplicate CLI removed (`src/app/trader_cli_simple.cpp`, `src/app/trader_cli_simple.hpp`).
 - Unused frontend testing component removed (`frontend/src/components/TestingSuite.jsx`).
+- Default API base URL removed to enforce explicit configuration (`frontend/src/services/api.ts`).
+- Redis stub context eliminated to ensure real integration (`src/util/redis_manager.*`).
 
 ## Recommendations
 1. Remove remaining hardcoded values via configuration.

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,7 +1,7 @@
 // SEP Trading System - API Service
 // Centralized API client for all backend communications
 
-const API_BASE_URL = process.env.REACT_APP_API_URL || process.env.REACT_APP_API_BASE_URL || 'http://localhost:5000';
+const API_BASE_URL = process.env.REACT_APP_API_URL || process.env.REACT_APP_API_BASE_URL || '';
 
 class APIClient {
   baseURL: string;

--- a/src/util/redis_manager.h
+++ b/src/util/redis_manager.h
@@ -1,13 +1,6 @@
 #pragma once
 
-#ifndef SEP_NO_REDIS
 #include <hiredis/hiredis.h>
-#define SEP_HAS_HIREDIS 1
-#else
-#define SEP_HAS_HIREDIS 0
-// Stub types when hiredis not available
-struct redisContext { int dummy; };
-#endif
 
 #include <memory>
 #include <mutex>


### PR DESCRIPTION
## Summary
- Drop hardcoded API base URL so the frontend always requires explicit configuration
- Remove Redis stub and conditional macros to rely solely on hiredis
- Document cleanup of default API URL and Redis stubs

## Testing
- `ctest` *(fails: No test configuration file found)*
- `CI=true npm test --silent` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab08930038832aa8f456bd91f0b564