### PR TITLE
Prune unimplemented trader CLI commands

### DIFF
--- a/docs/docs_archive/DATA_INTEGRITY_GUIDE.md
+++ b/docs/docs_archive/DATA_INTEGRITY_GUIDE.md
@@ -35,7 +35,7 @@ This guide clarifies the distinction between legitimate backtesting/simulation a
 ### **Mock/Test Data** ✅ IDENTIFIED
 **Files requiring validation**:
 - `/sep/src/engine/batch/batch_processor.cpp` - "Simulate execution" comments
-- `/sep/src/cli/trader_cli.cpp` - Mock health data (CPU usage = 45.0)
+- `/sep/src/cli/trader_cli.cpp` - Static status output only; no real metrics
 - `/sep/src/training/weekly_data_fetcher.cpp` - "Simulate data fetching"
 
 ## 🔄 DATA FLOW VERIFICATION
@@ -49,14 +49,8 @@ This guide clarifies the distinction between legitimate backtesting/simulation a
 
 ### **Testing Commands**
 ```bash
-# Verify real OANDA integration
+# Verify CLI status output
 ./build/src/cli/trader-cli status
-
-# Test real data fetching
-./build/src/cli/trader-cli train EUR_USD --hours 1
-
-# Validate system with real credentials
-./build/src/cli/trader-cli start
 ```
 
 ## 📊 PERFORMANCE VALIDATION

--- a/duplicate_implementations_report.md
+++ b/duplicate_implementations_report.md
@@ -29,6 +29,7 @@ This document tracks outstanding code quality concerns in the SEP Engine codebas
 - Default API base URL removed to enforce explicit configuration (`frontend/src/services/api.ts`).
 - Redis stub context eliminated to ensure real integration (`src/util/redis_manager.*`).
 - Stub CLI commands and duplicate kernel implementations removed (`src/core/cli_commands.*`, `src/core/kernel_implementations.cu`, `tests/unit/core/cli_commands_test.cpp`).
+- Unimplemented CLI command handlers pruned (`src/app/trader_cli.cpp`, `src/app/trader_cli.hpp`).
 
 ## Recommendations
 1. Remove remaining hardcoded values via configuration.

--- a/src/app/trader_cli.cpp
+++ b/src/app/trader_cli.cpp
@@ -79,11 +79,7 @@ void TraderCLI::print_help() const {
     printf("\nUsage: trader_cli <command> [options]\n\n");
     printf("Commands:\n");
     printf("  status       Show system status\n");
-    printf("  pairs        Manage trading pairs\n");
-    printf("  config       Configuration management\n");
-    printf("  train        Training operations\n");
-    printf("  analyze      Analysis operations\n");
-    printf("  daemon       Run in daemon mode\n");
+    printf("  pairs        List available trading pairs\n");
     printf("  help         Show this help message\n");
     printf("  version      Show version information\n\n");
     printf("Options:\n");
@@ -94,9 +90,6 @@ void TraderCLI::print_help() const {
     printf("Examples:\n");
     printf("  trader_cli status\n");
     printf("  trader_cli pairs list\n");
-    printf("  trader_cli config show\n");
-    printf("  trader_cli train start --pair EURUSD\n");
-    printf("  trader_cli daemon --foreground\n");
 }
 
 void TraderCLI::print_version() const {
@@ -117,14 +110,6 @@ int TraderCLI::execute_command(const char* command) {
         return handle_status();
     } else if (strcmp(command, "pairs") == 0) {
         return handle_pairs();
-    } else if (strcmp(command, "config") == 0) {
-        return handle_config();
-    } else if (strcmp(command, "train") == 0) {
-        return handle_train();
-    } else if (strcmp(command, "analyze") == 0) {
-        return handle_analyze();
-    } else if (strcmp(command, "daemon") == 0) {
-        return handle_daemon_mode();
     } else if (strcmp(command, "help") == 0) {
         print_help();
         return 0;
@@ -170,44 +155,6 @@ int TraderCLI::handle_pairs() const {
         printf("  %s\n", default_pairs[i]);
     }
     
-    return 0;
-}
-
-int TraderCLI::handle_config() const {
-    printf("Configuration Management\n");
-    printf("=======================\n");
-    printf("Config Directory: %s\n", config_path_);
-    printf("Status: Configuration loading not implemented in minimal mode\n");
-    return 0;
-}
-
-int TraderCLI::handle_train() const {
-    printf("Training Operations\n");
-    printf("==================\n");
-    printf("Status: Training operations not implemented in minimal mode\n");
-    printf("Use quantum processing components directly for training.\n");
-    return 0;
-}
-
-int TraderCLI::handle_analyze() const {
-    printf("Analysis Operations\n");
-    printf("==================\n");
-    printf("Status: Analysis operations not implemented in minimal mode\n");
-    printf("Use quantum processing components directly for analysis.\n");
-    return 0;
-}
-
-int TraderCLI::handle_daemon_mode() const {
-    printf("Daemon Mode\n");
-    printf("===========\n");
-    printf("Status: Daemon mode not implemented in minimal mode\n");
-    return 0;
-}
-
-int TraderCLI::handle_foreground_mode() const {
-    printf("Foreground Mode\n");
-    printf("===============\n");
-    printf("Status: Foreground mode not implemented in minimal mode\n");
     return 0;
 }
 

--- a/src/app/trader_cli.hpp
+++ b/src/app/trader_cli.hpp
@@ -20,11 +20,6 @@ private:
     int execute_command(const char* command);
     int handle_status() const;
     int handle_pairs() const;
-    int handle_config() const;
-    int handle_train() const;
-    int handle_analyze() const;
-    int handle_daemon_mode() const;
-    int handle_foreground_mode() const;
 
     // Simple C-style members
     bool verbose_;


### PR DESCRIPTION
## Summary
- simplify trader_cli to only support status and pair listing
- drop unused command handlers and update documentation

## Testing
- `ctest` *(fails: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab0c138fac832ab71f49affa299f3c