### PR TITLE
Cleanup duplicate pattern and memory utilities

### DIFF
--- a/duplicate_implementations_report.md
+++ b/duplicate_implementations_report.md
@@ -28,6 +28,7 @@ This document tracks outstanding code quality concerns in the SEP Engine codebas
 - Sample EUR/USD data helper and duplicate dataset removed (`src/io/oanda_connector.*`, `eur_usd_m1_48h.json`).
 - Redundant TraderCLI implementation and unused entry point removed (`src/app/trader_cli.*`, `src/app/app_main.cpp`).
 - Legacy dashboard component removed (`frontend/src/components/Dashboard.js`).
+- Duplicate PatternQuantumProcessor stub removed and memory utilities consolidated (`src/core/pattern_processor.cpp`, `src/cuda/memory.cu`).
 
 ## Recommendations
 1. Remove remaining hardcoded values via configuration.

--- a/src/core/pattern_processor.cpp
+++ b/src/core/pattern_processor.cpp
@@ -1,8 +1,7 @@
-// Merged from: src/core/bitspace/pattern_processor.cpp
 #include "core/pattern_processor.h"
 
-#include <numeric>
 #include <cmath>
+#include <numeric>
 
 namespace sep::quantum::bitspace {
 
@@ -11,13 +10,13 @@ PatternProcessor::PatternProcessor(std::map<std::string, std::vector<double>> hi
 
 Metrics PatternProcessor::processTrajectory(Trajectory& trajectory) {
     DampedValue damped_value = trajectory.calculateDampedValue();
-    
+
     Metrics metrics;
     metrics.coherence = calculateCoherence(damped_value);
     metrics.stability = calculateStability(damped_value);
     metrics.entropy = calculateEntropy(damped_value);
     metrics.confidence = matchHistoricalPaths(damped_value.path);
-    
+
     return metrics;
 }
 
@@ -26,8 +25,13 @@ double PatternProcessor::calculateCoherence(const DampedValue& damped_value) con
         return 0.5; // Neutral coherence for single-point path
     }
     // Coherence: 1 - normalized variance of the path
-    double mean = std::accumulate(damped_value.path.begin(), damped_value.path.end(), 0.0) / damped_value.path.size();
-    double sq_sum = std::inner_product(damped_value.path.begin(), damped_value.path.end(), damped_value.path.begin(), 0.0);
+    double mean = std::accumulate(damped_value.path.begin(), damped_value.path.end(), 0.0) /
+                  damped_value.path.size();
+    double sq_sum = std::inner_product(
+        damped_value.path.begin(),
+        damped_value.path.end(),
+        damped_value.path.begin(),
+        0.0);
     double variance = (sq_sum / damped_value.path.size()) - (mean * mean);
     return 1.0 - std::min(1.0, variance); // Clamp to [0, 1]
 }
@@ -48,7 +52,7 @@ double PatternProcessor::calculateEntropy(const DampedValue& damped_value) const
     // Entropy: Mean of absolute differences between path points
     double total_diff = 0.0;
     for (size_t i = 1; i < damped_value.path.size(); ++i) {
-        total_diff += std::abs(damped_value.path[i] - damped_value.path[i-1]);
+        total_diff += std::abs(damped_value.path[i] - damped_value.path[i - 1]);
     }
     return total_diff / (damped_value.path.size() - 1);
 }
@@ -78,7 +82,8 @@ double PatternProcessor::matchHistoricalPaths(const std::vector<double>& current
         }
 
         if (norm_current > 0 && norm_historical > 0) {
-            double similarity = dot_product / (std::sqrt(norm_current) * std::sqrt(norm_historical));
+            double similarity =
+                dot_product / (std::sqrt(norm_current) * std::sqrt(norm_historical));
             if (similarity > max_similarity) {
                 max_similarity = similarity;
             }
@@ -90,179 +95,3 @@ double PatternProcessor::matchHistoricalPaths(const std::vector<double>& current
 
 } // namespace sep::quantum::bitspace
 
-// Merged from: src/core/pattern_processor.cpp
-#include "core/common.h"
-#include "core/cuda_helpers.h"
-#include "core/core.h"
-#include "core/pattern_types.h"
-#include "core/types.h"
-#include "core/config.h"
-#include "core/pattern_evolution_bridge.h"
-#include "core/processor.h"
-#include "core/quantum_processor.h"
-
-using ::sep::memory::MemoryTierEnum;
-
-#include <glm/vec3.hpp>
-
-#include <algorithm>
-#include <memory>
-
-namespace sep::quantum {
-namespace {
-class PatternQuantumProcessorImpl final : public sep::pattern::PatternProcessor {
-public:
-    explicit PatternQuantumProcessorImpl(const QuantumProcessor::Config& config)
-        : quantum_processor_(createQuantumProcessor(config)) {}
-
-    sep::ProcessingResult processPattern(
-        const sep::quantum::Pattern& pattern) {
-        sep::ProcessingResult result;
-        result.pattern = pattern;
-        result.success = false;
-        
-        // Convert quantum state to a format the quantum processor can use
-        const auto& quantum_state = pattern.quantum_state;
-        glm::vec3 stateData(quantum_state.coherence, quantum_state.stability, quantum_state.entropy);
-        
-        // Process using quantum processor - use uint32_t hash directly
-        bool success =
-            quantum_processor_->processPattern(stateData, std::hash<uint32_t>{}(pattern.id));
-
-        result.success = success;
-        if (success) {
-            // Update quantum state values based on processing
-            auto& evolved_state = result.pattern.quantum_state;
-            evolved_state.coherence = std::min(1.0, quantum_state.coherence * 1.05);
-            evolved_state.stability = std::min(1.0, quantum_state.stability * 1.02);
-            evolved_state.generation++;
-
-            // Memory tier logic is handled elsewhere - no memory_tier field in QuantumState
-            result.success = true;
-        } else {
-            // Handle error case
-            auto& failed_state = result.pattern.quantum_state;
-            failed_state.coherence = 0.0f;
-            failed_state.stability = 0.0f;
-            result.error_message = "QuantumProcessor failed";
-            result.success = false;
-        }
-
-        return result;
-    }
-
-    std::vector<sep::ProcessingResult> processBatch(
-        const std::vector<sep::quantum::Pattern>& patterns)
-    {
-        std::vector<sep::ProcessingResult> results;
-        results.reserve(patterns.size());
-        
-        for (const auto& pattern : patterns) {
-            results.push_back(processPattern(pattern));
-        }
-        
-        return results;
-    }
-
-    float calculateCoherence(
-        const QuantumState& state_a,
-        const QuantumState& state_b) const {
-        // Convert states to vec3 format for quantum processor
-        glm::vec3 vec_a(state_a.coherence, state_a.stability, state_a.entropy);
-        glm::vec3 vec_b(state_b.coherence, state_b.stability, state_b.entropy);
-        
-        // Use quantum processor to calculate coherence
-        return quantum_processor_->calculateCoherence(vec_a, vec_b);
-    }
-
-    bool isStable(const QuantumState& state) const {
-        return state.stability >= sep::quantum::STABILITY_THRESHOLD;
-    }
-
-    bool isCollapsed(const QuantumState& state) const {
-        return state.coherence < sep::quantum::MIN_COHERENCE;
-    }
-bool isQuantum(const QuantumState& state) const {
-    return state.coherence >= sep::quantum::MIN_COHERENCE;
-}
-private:
-std::unique_ptr<QuantumProcessor> quantum_processor_;
-};
-}
-}
-
-// Function commented out to fix "defined but not used" error
-// std::unique_ptr<PatternQuantumProcessorImpl> createPatternQuantumProcessor(
-//     const ProcessingConfig& config)
-// {
-//     QuantumProcessor::Config qp_cfg{};
-//     qp_cfg.max_qubits = config.max_patterns;
-//     qp_cfg.decoherence_rate = config.mutation_rate;
-//     qp_cfg.measurement_threshold = config.ltm_coherence_threshold;
-//     qp_cfg.enable_gpu = config.enable_cuda;
-//     return std::make_unique<PatternQuantumProcessorImpl>(qp_cfg);
-// }
-
-namespace sep::pattern {
-
-PatternProcessor::PatternProcessor(Implementation impl) : implementation_(impl) {}
-
-sep::SEPResult PatternProcessor::init(quantum::GPUContext* ctx) {
-    if (implementation_ == Implementation::GPU)
-    {
-        if (!ctx)
-        {
-            return sep::SEPResult::INVALID_ARGUMENT;
-        }
-        CUDA_CHECK(cudaSetDevice(ctx->device_id));
-        CUDA_CHECK(cudaStreamCreate(reinterpret_cast<cudaStream_t*>(&ctx->default_stream)));
-        ctx->initialized = true;
-    }
-    return sep::SEPResult::SUCCESS;
-}
-
-void PatternProcessor::evolvePatterns() {
-    for (auto& pattern : patterns_) {
-        pattern = mutatePattern(pattern);
-    }
-}
-
-sep::compat::PatternData PatternProcessor::mutatePattern(const sep::compat::PatternData& parent)
-{
-    sep::compat::PatternData child = parent;
-    // child.generation = parent.generation + 1;
-    // child.id = parent.id + "_child";
-    return child;
-}
-
-sep::SEPResult PatternProcessor::addPattern(const sep::compat::PatternData& pattern)
-{
-    patterns_.push_back(pattern);
-    return sep::SEPResult::SUCCESS;
-}
-
-const std::vector<sep::compat::PatternData>& PatternProcessor::getPatterns() const
-{
-    return patterns_;
-}
-
-CPUPatternProcessor::CPUPatternProcessor() : PatternProcessor(Implementation::CPU), patterns_(PatternProcessor::patterns_) {}
-
-sep::SEPResult CPUPatternProcessor::init(quantum::GPUContext* ctx) { return PatternProcessor::init(ctx); }
-
-void CPUPatternProcessor::evolvePatterns() {
-    for (auto& p : patterns_) {
-        p = mutatePattern(p);
-    }
-}
-
-sep::compat::PatternData CPUPatternProcessor::mutatePattern(const sep::compat::PatternData& parent)
-{
-    return PatternProcessor::mutatePattern(parent);
-}
-
-} // namespace sep::pattern
-
-
-// Note: This file was auto-generated and might need manual adjustments
-// to align with the project's specific requirements.

--- a/src/cuda/memory.cu
+++ b/src/cuda/memory.cu
@@ -1,23 +1,24 @@
-// Merged from: src/core/internal/memory.cu
-// Disable fpclassify functions that cause conflicts with CUDA internal headers
-#define _DISABLE_FPCLASSIFY_FUNCTIONS 1
-#define __CUDA_INCLUDE_COMPILER_INTERNAL_HEADERS 1
-
 #include <cuda_runtime.h>
 
+#include <iostream>
 #include <stdexcept>
 
+#include "core/cuda_error.cuh"
+#include "device_buffer.h"
 #include "memory.h"
 
 namespace sep {
 namespace cuda {
 
+// RAII wrapper implementation
 template <typename T>
 DeviceMemory<T>::DeviceMemory(size_t size) : size_(size) {
     if (size > 0) {
         cudaError_t err = cudaMalloc(&ptr_, size_ * sizeof(T));
         if (err != cudaSuccess) {
-            throw std::runtime_error("Failed to allocate device memory: " + std::string(cudaGetErrorString(err)));
+            throw std::runtime_error(
+                "Failed to allocate device memory: " +
+                std::string(cudaGetErrorString(err)));
         }
     }
 }
@@ -30,7 +31,7 @@ DeviceMemory<T>::~DeviceMemory() {
 }
 
 template <typename T>
-DeviceMemory<T>::DeviceMemory(DeviceMemory&& other) noexcept 
+DeviceMemory<T>::DeviceMemory(DeviceMemory&& other) noexcept
     : ptr_(other.ptr_), size_(other.size_) {
     other.ptr_ = nullptr;
     other.size_ = 0;
@@ -60,41 +61,15 @@ size_t DeviceMemory<T>::size() const {
     return size_;
 }
 
-// Explicit template instantiations for common types
-template class DeviceMemory<float>;
-template class DeviceMemory<double>;
-template class DeviceMemory<int>;
-template class DeviceMemory<char>;
-
-}  // namespace cuda
-}  // namespace sep
-
-// Merged from: src/cuda/memory/memory.cu
-#include <cuda_runtime.h>
-
-#include <iostream>
-#include <mutex>
-#include <unordered_map>
-#include <vector>
-
-#include "device_buffer.h"
-#include "core/cuda_error.cuh"
-
-namespace sep {
-namespace cuda {
-
-// CUDA Memory Management Utilities
-
-// Get total and free device memory
+// Device memory utilities
 void getDeviceMemoryInfo(size_t& free, size_t& total) {
     CUDA_CHECK(cudaMemGetInfo(&free, &total));
 }
 
-// Print device memory usage statistics
 void printDeviceMemoryStats() {
     size_t free_mem, total_mem;
     CUDA_CHECK(cudaMemGetInfo(&free_mem, &total_mem));
-    
+
     std::cout << "CUDA Memory Usage:" << std::endl;
     std::cout << "  Total memory: " << (total_mem / (1024.0 * 1024.0)) << " MB" << std::endl;
     std::cout << "  Free memory:  " << (free_mem / (1024.0 * 1024.0)) << " MB" << std::endl;
@@ -102,7 +77,7 @@ void printDeviceMemoryStats() {
     std::cout << "  Usage:        " << ((total_mem - free_mem) * 100.0 / total_mem) << "%" << std::endl;
 }
 
-// Allocate pinned (page-locked) host memory
+// Pinned memory
 template <typename T>
 T* allocatePinnedMemory(size_t count) {
     T* ptr = nullptr;
@@ -110,7 +85,6 @@ T* allocatePinnedMemory(size_t count) {
     return ptr;
 }
 
-// Free pinned memory
 template <typename T>
 void freePinnedMemory(T* ptr) {
     if (ptr) {
@@ -118,7 +92,7 @@ void freePinnedMemory(T* ptr) {
     }
 }
 
-// Allocate managed memory (unified memory)
+// Managed memory
 template <typename T>
 T* allocateManagedMemory(size_t count) {
     T* ptr = nullptr;
@@ -126,7 +100,6 @@ T* allocateManagedMemory(size_t count) {
     return ptr;
 }
 
-// Free managed memory
 template <typename T>
 void freeManagedMemory(T* ptr) {
     if (ptr) {
@@ -134,25 +107,27 @@ void freeManagedMemory(T* ptr) {
     }
 }
 
-// Prefetch managed memory to device
 template <typename T>
 void prefetchToDevice(T* ptr, size_t count, int device_id) {
     CUDA_CHECK(cudaMemPrefetchAsync(ptr, count * sizeof(T), device_id));
 }
 
-// Prefetch managed memory to host
 template <typename T>
 void prefetchToHost(T* ptr, size_t count) {
     CUDA_CHECK(cudaMemPrefetchAsync(ptr, count * sizeof(T), cudaCpuDeviceId));
 }
 
-// Zero memory on device
 template <typename T>
 void zeroDeviceMemory(T* device_ptr, size_t count) {
     CUDA_CHECK(cudaMemset(device_ptr, 0, count * sizeof(T)));
 }
 
-// Explicit template instantiations for common types
+// Explicit template instantiations
+template class DeviceMemory<float>;
+template class DeviceMemory<double>;
+template class DeviceMemory<int>;
+template class DeviceMemory<char>;
+
 template uint32_t* allocatePinnedMemory<uint32_t>(size_t);
 template void freePinnedMemory<uint32_t>(uint32_t*);
 template uint32_t* allocateManagedMemory<uint32_t>(size_t);
@@ -180,39 +155,3 @@ template void zeroDeviceMemory<double>(double*, size_t);
 } // namespace cuda
 } // namespace sep
 
-// Merged from: src/util/memory.cu
-// GLM isolation layer
-// Include CUDA compatibility layer for C++ standard library functions
-
-// Include CUDA headers
-#include <cstring>
-#include <cstring>  // For std::memcpy (if needed implicitly for unified memory)
-
-#include "cuda.h"
-#include "util/raii.h"
-#include "core/types.h"
-
-namespace sep {
-
-// NOTE: UnifiedMemory template class implementation is now provided inline in unified_memory.h
-// This file only provides explicit template instantiations for common types
-
-// Explicit instantiations for common types
-template class UnifiedMemory<char>;
-template class UnifiedMemory<unsigned char>;
-template class UnifiedMemory<short>;
-template class UnifiedMemory<unsigned short>;
-template class UnifiedMemory<int>;
-template class UnifiedMemory<unsigned int>;
-template class UnifiedMemory<long>;
-template class UnifiedMemory<unsigned long>;
-template class UnifiedMemory<long long>;
-template class UnifiedMemory<unsigned long long>;
-template class UnifiedMemory<float>;
-template class UnifiedMemory<double>;
-
-} // namespace sep
-
-
-// Note: This file was auto-generated and might need manual adjustments
-// to align with the project's specific requirements.


### PR DESCRIPTION
## Summary
- remove legacy PatternQuantumProcessor stub and keep real trajectory processor
- consolidate CUDA memory utilities and drop auto-generated placeholder
- document cleanup in duplicate implementations report

## Testing
- `ctest` *(fails: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab0f731ffc832a8ceffd6d1266aadb