### PR TITLE
chore: remove unused dsl stubs

### DIFF
--- a/duplicate_implementations_report.md
+++ b/duplicate_implementations_report.md
@@ -30,6 +30,7 @@ This document tracks outstanding code quality concerns in the SEP Engine codebas
 - Legacy dashboard component removed (`frontend/src/components/Dashboard.js`).
 - Redundant JavaScript SymbolContext removed (`frontend/src/context/SymbolContext.js`)
   in favor of the typed implementation.
+- Unused DSL aggregation and data transformation stubs removed (`src/util/aggregation.*`, `src/util/data_transformation.*`).
 
 ## Recommendations
 1. Remove remaining hardcoded values via configuration.

--- a/src/util/aggregation.cpp
+++ b/src/util/aggregation.cpp
@@ -1,9 +1,0 @@
-#include "aggregation.h"
-
-namespace sep::dsl::stdlib {
-
-void register_aggregation([[maybe_unused]] Runtime& runtime) {
-    // Registration for aggregation functions will go here.
-}
-
-}  // namespace sep::dsl::stdlib

--- a/src/util/aggregation.h
+++ b/src/util/aggregation.h
@@ -1,9 +1,0 @@
-#pragma once
-
-namespace sep::dsl::stdlib {
-
-class Runtime;
-
-void register_aggregation(Runtime& runtime);
-
-}

--- a/src/util/data_transformation.cpp
+++ b/src/util/data_transformation.cpp
@@ -1,9 +1,0 @@
-#include "data_transformation.h"
-
-namespace sep::dsl::stdlib {
-
-void register_data_transformation([[maybe_unused]] Runtime& runtime) {
-    // Registration for data transformation functions will go here.
-}
-
-}  // namespace sep::dsl::stdlib

--- a/src/util/data_transformation.h
+++ b/src/util/data_transformation.h
@@ -1,9 +1,0 @@
-#pragma once
-
-namespace sep::dsl::stdlib {
-
-class Runtime;
-
-void register_data_transformation(Runtime& runtime);
-
-}


### PR DESCRIPTION
## Summary
- remove unused DSL aggregation and data transformation stubs
- document the cleanup in duplicate implementations report

## Testing
- no tests were run

------
https://chatgpt.com/codex/tasks/task_e_68ab10ca19a4832abfdae02c1cc4f78f