### PR TITLE
Remove demo trading data hooks

### DIFF
--- a/src/core/status_display.cpp
+++ b/src/core/status_display.cpp
@@ -74,20 +74,9 @@ bool StatusDisplay::showTuningStatus() {
     printStatusHeader("Live Tuning Status");
     
     bool tuning_active = false;  // Simplified for now
-    
+
     std::cout << "\n🎯 LIVE TUNING:" << std::endl;
     printStatusLine("Status", tuning_active ? "Active" : "Inactive", tuning_active);
-    
-    if (tuning_active) {
-        printStatusLine("Tuning Pairs", "3", true);
-        printStatusLine("Iteration", "42", true);
-        printStatusLine("Last Update", "2 minutes ago", true);
-        
-        std::cout << "\n📈 CURRENT PERFORMANCE:" << std::endl;
-        printStatusLine("EUR_USD Accuracy", "68.5%", true);
-        printStatusLine("GBP_USD Accuracy", "71.2%", true);
-        printStatusLine("USD_JPY Accuracy", "66.8%", true);
-    }
     
     return true;
 }

--- a/src/util/interpreter.cpp
+++ b/src/util/interpreter.cpp
@@ -1720,35 +1720,22 @@ void Interpreter::register_builtins() {
         if (args.empty()) {
             throw std::runtime_error("get_current_price() expects instrument argument");
         }
-        
+
         std::string instrument = std::any_cast<std::string>(args[0]);
-        std::cout << "DSL: Getting current price for " << instrument << std::endl;
-        
-        // Demo prices - in production, fetch from OANDA
-        if (instrument == "EUR_USD") return 1.0892;
-        if (instrument == "GBP_USD") return 1.2654;
-        if (instrument == "USD_JPY") return 148.25;
-        if (instrument == "USD_CHF") return 0.8934;
-        
-        return 1.0000; // Default
+        (void)instrument; // placeholder until real data source integrated
+        throw std::runtime_error("get_current_price() not connected to real data");
     };
-    
+
     builtins_["get_average_true_range"] = [](const std::vector<Value>& args) -> Value {
         if (args.size() < 2) {
             throw std::runtime_error("get_average_true_range() expects (instrument, periods) arguments");
         }
-        
+
         std::string instrument = std::any_cast<std::string>(args[0]);
         double periods = std::any_cast<double>(args[1]);
-        
-        std::cout << "DSL: Calculating ATR(" << periods << ") for " << instrument << std::endl;
-        
-        // Demo ATR values - in production, calculate from real data
-        if (instrument == "EUR_USD") return 0.0015; // 15 pips
-        if (instrument == "GBP_USD") return 0.0020; // 20 pips
-        if (instrument == "USD_JPY") return 0.45;   // 45 points
-        
-        return 0.0010; // Default
+        (void)instrument;
+        (void)periods;
+        throw std::runtime_error("get_average_true_range() not connected to real data");
     };
     
     // Advanced trading functions


### PR DESCRIPTION
## Summary
- remove demo price and ATR builtins so interpreter no longer returns spoofed values
- drop unused tuning metrics placeholders from status display

## Testing
- `ctest` *(fails: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab10ca19a4832abfdae02c1cc4f78f