### PR TITLE
Remove obsolete market data stubs

### DIFF
--- a/docs/docs_archive/DATA_INTEGRITY_GUIDE.md
+++ b/docs/docs_archive/DATA_INTEGRITY_GUIDE.md
@@ -35,7 +35,6 @@ This guide clarifies the distinction between legitimate backtesting/simulation a
 **Files requiring validation**:
 - `/sep/src/engine/batch/batch_processor.cpp` - "Simulate execution" comments
 - `/sep/src/cli/trader_cli.cpp` - Static status output only; no real metrics
-- `/sep/src/training/weekly_data_fetcher.cpp` - "Simulate data fetching"
 
 ## 🔄 DATA FLOW VERIFICATION
 

--- a/src/util/interpreter.cpp
+++ b/src/util/interpreter.cpp
@@ -1715,29 +1715,6 @@ void Interpreter::register_builtins() {
         }
     };
     
-    // Market data functions
-    builtins_["get_current_price"] = [](const std::vector<Value>& args) -> Value {
-        if (args.empty()) {
-            throw std::runtime_error("get_current_price() expects instrument argument");
-        }
-
-        std::string instrument = std::any_cast<std::string>(args[0]);
-        (void)instrument; // placeholder until real data source integrated
-        throw std::runtime_error("get_current_price() not connected to real data");
-    };
-
-    builtins_["get_average_true_range"] = [](const std::vector<Value>& args) -> Value {
-        if (args.size() < 2) {
-            throw std::runtime_error("get_average_true_range() expects (instrument, periods) arguments");
-        }
-
-        std::string instrument = std::any_cast<std::string>(args[0]);
-        double periods = std::any_cast<double>(args[1]);
-        (void)instrument;
-        (void)periods;
-        throw std::runtime_error("get_average_true_range() not connected to real data");
-    };
-    
     // Advanced trading functions
     builtins_["check_market_hours"] = [](const std::vector<Value>& args) -> Value {
         (void)args; // Suppress unused parameter warning


### PR DESCRIPTION
## Summary
- Remove unimplemented `get_current_price` and `get_average_true_range` built-ins from the interpreter
- Drop outdated reference to mock weekly data fetcher in data integrity guide

## Testing
- `ctest` *(fails: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab11d97a24832ab2561ceecc10d0a3