### PR TITLE
Remove unimplemented market data DSL builtins

### DIFF
--- a/duplicate_implementations_report.md
+++ b/duplicate_implementations_report.md
@@ -33,6 +33,7 @@ This document tracks outstanding code quality concerns in the SEP Engine codebas
 - Placeholder quantum state replaced with real implementation
   (`src/core/pattern_types.h`, `src/core/types_serialization.cpp`).
 - Unused DSL aggregation and data transformation stubs removed (`src/util/aggregation.*`, `src/util/data_transformation.*`).
+- Unimplemented market data DSL builtins removed (`src/util/interpreter.cpp`).
 
 ## Recommendations
 1. Remove remaining hardcoded values via configuration.

--- a/src/util/interpreter.cpp
+++ b/src/util/interpreter.cpp
@@ -1715,29 +1715,6 @@ void Interpreter::register_builtins() {
         }
     };
     
-    // Market data functions
-    builtins_["get_current_price"] = [](const std::vector<Value>& args) -> Value {
-        if (args.empty()) {
-            throw std::runtime_error("get_current_price() expects instrument argument");
-        }
-
-        std::string instrument = std::any_cast<std::string>(args[0]);
-        (void)instrument; // placeholder until real data source integrated
-        throw std::runtime_error("get_current_price() not connected to real data");
-    };
-
-    builtins_["get_average_true_range"] = [](const std::vector<Value>& args) -> Value {
-        if (args.size() < 2) {
-            throw std::runtime_error("get_average_true_range() expects (instrument, periods) arguments");
-        }
-
-        std::string instrument = std::any_cast<std::string>(args[0]);
-        double periods = std::any_cast<double>(args[1]);
-        (void)instrument;
-        (void)periods;
-        throw std::runtime_error("get_average_true_range() not connected to real data");
-    };
-    
     // Advanced trading functions
     builtins_["check_market_hours"] = [](const std::vector<Value>& args) -> Value {
         (void)args; // Suppress unused parameter warning


### PR DESCRIPTION
## Summary
- prune `get_current_price` and `get_average_true_range` DSL helpers that only threw errors
- note builtin removal in duplicate implementation report

## Testing
- no tests were run

------
https://chatgpt.com/codex/tasks/task_e_68ab124b8e24832a87bf44d701395204