### PR TITLE
Remove testbed OANDA helper

### DIFF
--- a/docs/docs_archive/mock_implementation_inventory.md
+++ b/docs/docs_archive/mock_implementation_inventory.md
@@ -17,9 +17,9 @@ During our initial scan, we identified the following mock implementations and re
 
 ### Data Source Mocks
 
-1. **OANDA Market Data Helper** (`_sep/testbed/oanda_market_data_helper.hpp`)
-   - Contains a placeholder ATR value set to 0.0 instead of real computation
-   - Used for test data transformation
+1. **OANDA Market Data Helper**
+   - Previously located at `_sep/testbed/oanda_market_data_helper.hpp` with a placeholder ATR value
+   - Now integrated into `src/app/quantum_signal_bridge.cpp` with real ATR computation
 
 2. **Cache Validation** (Referenced in `tests/data_pipeline/test_data_integrity.cpp`)
    - Ensures cached entries originate from recognized providers (e.g., OANDA)
@@ -67,7 +67,7 @@ During our initial scan, we identified the following mock implementations and re
 | Component | Location | Type | Purpose | Status |
 |-----------|----------|------|---------|--------|
 | PlaceholderDetection | `_sep/testbed/placeholder_detection.h` | Utility | Detect placeholder values in production | Identified |
-| OandaMarketDataHelper | `_sep/testbed/oanda_market_data_helper.hpp` | Helper | Transform market data with placeholder ATR | Identified |
+| OandaMarketDataHelper | `src/app/quantum_signal_bridge.cpp` | Helper | Fetches OANDA data with ATR calculation | Resolved |
 | CacheValidator | Referenced in tests | Validation | Validate real data providers | Updated |
 | ServiceInterfaces | `src/app/*` | Interface | Define service contracts | Consolidated |
 | MemoryTierServiceStub | `src/app/MemoryTierService.*` | Service | Mock memory tier management | Removed |

--- a/duplicate_implementations_report.md
+++ b/duplicate_implementations_report.md
@@ -34,6 +34,8 @@ This document tracks outstanding code quality concerns in the SEP Engine codebas
   (`src/core/pattern_types.h`, `src/core/types_serialization.cpp`).
 - Unused DSL aggregation and data transformation stubs removed (`src/util/aggregation.*`, `src/util/data_transformation.*`).
 - Unimplemented market data DSL builtins removed (`src/util/interpreter.cpp`).
+- Testbed OANDA market data helper migrated to production with real ATR
+  (`src/app/quantum_signal_bridge.cpp`).
 
 ## Recommendations
 1. Remove remaining hardcoded values via configuration.

--- a/src/app/quantum_signal_bridge.cpp
+++ b/src/app/quantum_signal_bridge.cpp
@@ -12,13 +12,13 @@
 #include <iomanip>
 #include <iostream>
 #include <sstream>
+#include <stdexcept>
 
 #include "app/candle_types.h"
 
 #include "cuda/bit_pattern_kernels.h"
 #include "core/pattern_processor.h"
 #include "core/quantum_manifold_optimizer.h"
-#include "../../_sep/testbed/oanda_market_data_helper.hpp"
 #include "core/signal.h"
 #include "core/types_serialization.h"
 #include "io/oanda_connector.h"
@@ -53,6 +53,61 @@ void from_json(const json& j, Candle& c) {
         j.at("close").get_to(c.close);
     }
 }
+
+namespace {
+std::vector<sep::connectors::MarketData> fetchMarketData(
+    sep::connectors::OandaConnector& connector,
+    const std::string& pair_symbol,
+    size_t hours_back) {
+    using namespace std::chrono;
+
+    auto now = system_clock::now();
+    auto start_time = now - hours(hours_back);
+
+    auto formatTimestamp = [](const system_clock::time_point& tp) {
+        auto time_t = system_clock::to_time_t(tp);
+        std::stringstream ss;
+        ss << std::put_time(std::gmtime(&time_t), "%Y-%m-%dT%H:%M:%SZ");
+        return ss.str();
+    };
+
+    std::string from_str = formatTimestamp(start_time);
+    std::string to_str = formatTimestamp(now);
+
+    auto oanda_candles = connector.getHistoricalData(pair_symbol, "M1", from_str, to_str);
+    if (oanda_candles.empty()) {
+        throw std::runtime_error("No historical data returned from OANDA");
+    }
+
+    std::vector<sep::connectors::MarketData> market_data;
+    market_data.reserve(oanda_candles.size());
+
+    double atr = 0.0;
+    const size_t period = 14;
+    for (const auto& candle : oanda_candles) {
+        sep::connectors::MarketData md;
+        md.instrument = pair_symbol;
+        md.timestamp = duration_cast<milliseconds>(parseTimestamp(candle.time).time_since_epoch()).count();
+        md.mid = candle.close;
+        md.bid = candle.low;
+        md.ask = candle.high;
+        md.volume = candle.volume;
+
+        double tr;
+        if (market_data.empty()) {
+            tr = candle.high - candle.low;
+        } else {
+            double prev_close = market_data.back().mid;
+            tr = std::max({candle.high - candle.low, std::abs(candle.high - prev_close), std::abs(candle.low - prev_close)});
+        }
+        atr = market_data.empty() ? tr : atr + (tr - atr) / std::min(period, market_data.size() + 1.0);
+        md.atr = atr;
+        market_data.push_back(md);
+    }
+
+    return market_data;
+}
+} // anonymous namespace
 
 namespace sep::trading {
 
@@ -1040,7 +1095,7 @@ sep::trading::QuantumIdentifiers sep::trading::QuantumSignalBridge::processAsset
             try {
                 sep::connectors::OandaConnector connector(api_key, account_id);
                 if (connector.initialize()) {
-                    recent_data = sep::testbed::fetchMarketData(connector, asset, 1);
+                    recent_data = fetchMarketData(connector, asset, 1);
                     connector.shutdown();
                 }
             } catch (const std::exception& e) {


### PR DESCRIPTION
## Summary
- Inline OANDA market data fetching with ATR calculation into QuantumSignalBridge
- Drop dependency on testbed helper and document the migration

## Testing
- `ctest` *(fails: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab13e135f4832aa232efcdc2386983