### PR TITLE
docs: align env template references

### DIFF
--- a/docs/01_DEPLOYMENT_INTEGRATION_GUIDE.md
+++ b/docs/01_DEPLOYMENT_INTEGRATION_GUIDE.md
@@ -79,8 +79,8 @@ cd sep-trader
 ./install.sh --minimal --no-docker
 ./build.sh --no-docker
 
-# 3. Environment Configuration  
-cp .sep-config.env.example .sep-config.env
+# 3. Environment Configuration
+cp config/.sep-config.env.template .sep-config.env
 # Edit configuration as needed
 
 # 4. Service Deployment

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -12,7 +12,7 @@ This directory contains the React + TypeScript front‑end for the SEP Professio
 ```bash
 cd frontend
 npm install        # or pnpm install
-cp .env.example .env  # edit API / WS URLs if necessary
+cp .env.template .env  # edit API / WS URLs if necessary
 npm start          # Runs the app in development mode on http://localhost:3000
 ```
 


### PR DESCRIPTION
## Summary
- correct frontend docs to copy `.env.template`
- fix deployment guide to reference `config/.sep-config.env.template`

## Testing
- no tests run

------
https://chatgpt.com/codex/tasks/task_e_68ab13e135f4832aa232efcdc2386983