### PR TITLE
chore: remove unused manifold and websocket state

### DIFF
--- a/frontend/src/context/ManifoldContext.js
+++ b/frontend/src/context/ManifoldContext.js
@@ -14,10 +14,7 @@ export const ManifoldProvider = ({ children }) => {
   } = useWebSocket();
 
   // Enhanced manifold state management
-  const [manifestoData, setManifestoData] = useState(new Map());
-  const [identityTimelines, setIdentityTimelines] = useState(new Map());
   const [ruptureEvents, setRuptureEvents] = useState([]);
-  const [patternEvolution, setPatternEvolution] = useState([]);
   const [selectedIdentity, setSelectedIdentity] = useState(null);
 
   // Process quantum signals into identity timelines
@@ -165,8 +162,7 @@ export const ManifoldProvider = ({ children }) => {
     processedIdentities,
     manifoldBands,
     ruptureEvents,
-    patternEvolution,
-    
+
     // Selection state
     selectedIdentity,
     setSelectedIdentity,

--- a/frontend/src/context/WebSocketContext.js
+++ b/frontend/src/context/WebSocketContext.js
@@ -25,12 +25,6 @@ export const WebSocketProvider = ({ children }) => {
   const [valkeyMetrics, setValkeyMetrics] = useState({});
   const [livePatterns, setLivePatterns] = useState({});
   
-  // Enhanced states for backwards computation & manifold streaming
-  const [manifoldStream, setManifoldStream] = useState({});
-  const [pinStates, setPinStates] = useState(new Map());
-  const [signalEvolution, setSignalEvolution] = useState(new Map());
-  const [backwardsDerivations, setBackwardsDerivations] = useState(new Map());
-  
   // Connection management
   const reconnectTimeoutRef = useRef(null);
   const reconnectAttemptsRef = useRef(0);


### PR DESCRIPTION
## Summary
- remove unused placeholder state from ManifoldContext
- drop unused manifold streaming state from WebSocketContext

## Testing
- `ctest` *(fails: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab16068214832ab740eae2bfdbc0df