### PR TITLE
Require explicit WebSocket configuration

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -196,8 +196,8 @@ case "$COMMAND" in
         sleep 10
         log_success "SEP Trading System is running locally!"
         log_info "Frontend: http://localhost"
-        log_info "Backend API: http://localhost:5000"
-        log_info "WebSocket: ws://localhost:8765"
+        log_info "Backend API: ${REACT_APP_API_URL:-<not configured>}"
+        log_info "WebSocket: ${REACT_APP_WS_URL:-<not configured>}"
         ;;
     "remote")
         update_github

--- a/docs/01_DEPLOYMENT_INTEGRATION_GUIDE.md
+++ b/docs/01_DEPLOYMENT_INTEGRATION_GUIDE.md
@@ -115,7 +115,7 @@ SEP_CONFIG_PATH=/app/config
 PYTHONPATH=/app
 PORT=5000
 REACT_APP_API_URL=http://localhost:5000
-REACT_APP_WS_URL=ws://localhost:8765
+REACT_APP_WS_URL=<websocket-url>
 REACT_APP_ENVIRONMENT=development
 EOF
 ```
@@ -321,7 +321,7 @@ CORS_ORIGINS=http://localhost,http://129.212.145.195
 ```bash
 # Local development
 REACT_APP_API_URL=http://localhost:5000
-REACT_APP_WS_URL=ws://localhost:8765
+REACT_APP_WS_URL=<websocket-url>
 REACT_APP_ENVIRONMENT=development
 
 # Production

--- a/docs/02_WEB_INTERFACE_ARCHITECTURE.md
+++ b/docs/02_WEB_INTERFACE_ARCHITECTURE.md
@@ -483,7 +483,7 @@ export const useTradingData = () => {
     
     // Real-time updates
     const ws = new WebSocketService()
-    ws.connect('ws://localhost:8765/trade-signals')
+    ws.connect(`${process.env.REACT_APP_WS_URL}/trade-signals`)
       .then(() => {
         ws.subscribe('trading-status', (data) => {
           setTradingData(prev => ({ ...prev, ...data }))
@@ -507,7 +507,7 @@ export const usePerformance = () => {
     
     // Real-time performance updates
     const ws = new WebSocketService()
-    ws.connect('ws://localhost:8765/performance')
+    ws.connect(`${process.env.REACT_APP_WS_URL}/performance`)
       .then(() => {
         ws.subscribe('metrics-update', setMetrics)
         ws.subscribe('history-update', (data) => {

--- a/docs/README.md
+++ b/docs/README.md
@@ -45,8 +45,8 @@ npm start       # launch development server
 Runtime settings are configured via environment variables. In development, create `frontend/.env`:
 
 ```
-REACT_APP_API_URL=http://localhost:5000
-REACT_APP_WS_URL=ws://localhost:8765
+REACT_APP_API_URL=<backend-api-url>
+REACT_APP_WS_URL=<websocket-url>
 ```
 
 For production builds:

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -5,7 +5,7 @@ This directory contains the React + TypeScript front‑end for the SEP Professio
 **Prerequisites**
 
 * Node.js 18.x (see `.nvmrc`).
-* A running SEP engine backend on `http://localhost:5000` (REST) and `ws://localhost:8765` (WebSocket) or set custom URLs in `.env`.
+* A running SEP engine backend with REST and WebSocket endpoints configured via `.env`.
 
 **Getting Started**
 
@@ -18,8 +18,8 @@ npm start          # Runs the app in development mode on http://localhost:3000
 
 **Environment Variables**
 
-* `REACT_APP_API_URL`: Base URL for REST API (default `http://localhost:5000`).
-* `REACT_APP_WS_URL`: WebSocket endpoint for real‑time data (default `ws://localhost:8765`).
+* `REACT_APP_API_URL`: Base URL for REST API.
+* `REACT_APP_WS_URL`: WebSocket endpoint for real‑time data.
 
 **Building for production**
 

--- a/frontend/src/context/WebSocketContext.js
+++ b/frontend/src/context/WebSocketContext.js
@@ -5,7 +5,10 @@ import React, { createContext, useContext, useEffect, useRef, useState, useCallb
 
 const WebSocketContext = createContext(null);
 
-const WS_URL = process.env.REACT_APP_WS_URL || process.env.REACT_APP_WS_BASE_URL || window._env_?.REACT_APP_WS_URL || 'ws://localhost:8765';
+const WS_URL =
+  process.env.REACT_APP_WS_URL ||
+  process.env.REACT_APP_WS_BASE_URL ||
+  window._env_?.REACT_APP_WS_URL;
 
 export const WebSocketProvider = ({ children }) => {
   const [socket, setSocket] = useState(null);
@@ -250,6 +253,11 @@ export const WebSocketProvider = ({ children }) => {
 
   // Connect to WebSocket
   const connect = useCallback(() => {
+    if (!WS_URL) {
+      console.error('WebSocket URL not configured');
+      setConnectionStatus('configuration-error');
+      return;
+    }
     if (socket?.readyState === WebSocket.OPEN) {
       console.log('WebSocket already connected');
       return;
@@ -257,7 +265,7 @@ export const WebSocketProvider = ({ children }) => {
 
     console.log(`Connecting to WebSocket at ${WS_URL}...`);
     setConnectionStatus('connecting');
-    
+
     try {
       const ws = new WebSocket(WS_URL);
       


### PR DESCRIPTION
## Summary
- Remove hardcoded WebSocket fallback and block connection when no URL is configured
- Update deployment script and docs to use environment-driven WebSocket URLs

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68ab16068214832ab740eae2bfdbc0df