### PR TITLE
Remove mock trade simulation and unused evolution helpers

### DIFF
--- a/duplicate_implementations_report.md
+++ b/duplicate_implementations_report.md
@@ -36,6 +36,7 @@ This document tracks outstanding code quality concerns in the SEP Engine codebas
 - Unimplemented market data DSL builtins removed (`src/util/interpreter.cpp`).
 - Testbed OANDA market data helper migrated to production with real ATR
   (`src/app/quantum_signal_bridge.cpp`).
+- Unused evolutionary helper declarations and mock trade simulation removed (`src/core/evolution.h`, `src/util/interpreter.cpp`).
 
 ## Recommendations
 1. Remove remaining hardcoded values via configuration.

--- a/src/core/evolution.h
+++ b/src/core/evolution.h
@@ -71,11 +71,7 @@ Pattern blendCrossover(const Pattern& parent1, const Pattern& parent2, float alp
 float coherenceFitness(const Pattern& pattern);
 float stabilityFitness(const Pattern& pattern);
 float complexityFitness(const Pattern& pattern);
-std::vector<Pattern> createRandomPopulation(size_t size);
-void applySpike(Pattern& neuron, float input, float decay, float threshold);
-void hebbianUpdate(const Pattern& pre, Pattern& post, float rate);
-void applyGravity(Pattern& pattern, const glm::vec3& center, float strength);
-void randomPerturbation(Pattern& pattern, float amplitude);
+// Removed unused experimental evolution helpers
 } // namespace evolution
 
 BatchProcessingResult evolve(const EvolutionParams& params);

--- a/src/util/interpreter.cpp
+++ b/src/util/interpreter.cpp
@@ -1752,43 +1752,6 @@ void Interpreter::register_builtins() {
         return "historical_data_" + instrument + "_" + timeframe; // Fallback
     };
     
-    builtins_["simulate_trade_outcome"] = [](const std::vector<Value>& args) -> Value {
-        if (args.empty()) {
-            throw std::runtime_error("simulate_trade_outcome() expects data_point argument");
-        }
-        
-        // Simulate trade outcome for backtesting
-        // Use real market movements from the pattern engine
-        // This would integrate with actual market data and pattern analysis
-        // For now, we'll use a more sophisticated approach than simple random
-        static sep::quantum::PatternMetricEngine metricEngine;
-        static bool initialized = false;
-        if (!initialized) {
-            metricEngine.init(nullptr); // Initialize for CPU operation
-            initialized = true;
-        }
-        
-        // Simulate a more realistic outcome based on pattern analysis
-        // In a real implementation, this would use actual market data
-        double outcome = 0.0;
-        
-        // Get current metrics from the engine
-        const auto& metrics = metricEngine.computeMetrics();
-        if (!metrics.empty()) {
-            // Use coherence and stability to determine outcome
-            double coherence = metrics[0].coherence;
-            double stability = metrics[0].stability;
-            
-            // More coherent and stable patterns suggest positive outcomes
-            outcome = (coherence * 0.6 + stability * 0.4) * 100.0 - 50.0;
-        } else {
-            // Fallback to a more balanced random approach
-            outcome = (static_cast<double>(rand() % 100) - 50.0) * 0.6;
-        }
-        
-        return outcome;
-    };
-    
     // Strategy performance tracking
     builtins_["log_trade_result"] = [](const std::vector<Value>& args) -> Value {
         if (args.size() < 3) {


### PR DESCRIPTION
## Summary
- Drop the unused `simulate_trade_outcome` DSL builtin to remove mock trade logic
- Prune stale evolution helper declarations that were never implemented
- Document the cleanup in `duplicate_implementations_report.md`

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_e_68ab1744bbcc832a8e81010d63800e49