### PR TITLE
Remove placeholder market data fetcher

### DIFF
--- a/duplicate_implementations_report.md
+++ b/duplicate_implementations_report.md
@@ -36,6 +36,8 @@ This document tracks outstanding code quality concerns in the SEP Engine codebas
 - Unimplemented market data DSL builtins removed (`src/util/interpreter.cpp`).
 - Testbed OANDA market data helper migrated to production with real ATR
   (`src/app/quantum_signal_bridge.cpp`).
+- Removed duplicate market data fetcher and placeholder ATR
+  (`src/app/quantum_signal_bridge.cpp`).
 
 ## Recommendations
 1. Remove remaining hardcoded values via configuration.

--- a/src/app/quantum_signal_bridge.cpp
+++ b/src/app/quantum_signal_bridge.cpp
@@ -26,47 +26,6 @@
 
 using json = nlohmann::json;
 
-static std::vector<sep::connectors::MarketData> fetchRecentMarketData(
-    sep::connectors::OandaConnector& connector,
-    const std::string& pair_symbol,
-    size_t hours_back) {
-    auto now = std::chrono::system_clock::now();
-    auto start_time = now - std::chrono::hours(hours_back);
-
-    auto formatTimestamp = [](const std::chrono::system_clock::time_point& tp) {
-        auto time_t = std::chrono::system_clock::to_time_t(tp);
-        std::stringstream ss;
-        ss << std::put_time(std::gmtime(&time_t), "%Y-%m-%dT%H:%M:%SZ");
-        return ss.str();
-    };
-
-    std::string from_str = formatTimestamp(start_time);
-    std::string to_str = formatTimestamp(now);
-
-    auto oanda_candles = connector.getHistoricalData(pair_symbol, "M1", from_str, to_str);
-    if (oanda_candles.empty()) {
-        throw std::runtime_error("No historical data returned from OANDA");
-    }
-
-    std::vector<sep::connectors::MarketData> market_data;
-    market_data.reserve(oanda_candles.size());
-    for (const auto& candle : oanda_candles) {
-        sep::connectors::MarketData md;
-        md.instrument = pair_symbol;
-        md.timestamp = std::chrono::duration_cast<std::chrono::milliseconds>(
-                            sep::common::parseTimestamp(candle.time).time_since_epoch())
-                            .count();
-        md.mid = candle.close;
-        md.bid = candle.low;
-        md.ask = candle.high;
-        md.volume = candle.volume;
-        md.atr = 0.0; // TODO: compute ATR
-        market_data.push_back(md);
-    }
-
-    return market_data;
-}
-
 void from_json(const json& j, Candle& c) {
     std::string time_str;
     j.at("time").get_to(time_str);
@@ -1136,7 +1095,7 @@ sep::trading::QuantumIdentifiers sep::trading::QuantumSignalBridge::processAsset
             try {
                 sep::connectors::OandaConnector connector(api_key, account_id);
                 if (connector.initialize()) {
-                    recent_data = fetchRecentMarketData(connector, asset, 1);
+                    recent_data = fetchMarketData(connector, asset, 1);
                     connector.shutdown();
                 }
             } catch (const std::exception& e) {


### PR DESCRIPTION
## Summary
- remove duplicate OANDA market data fetcher that returned ATR=0
- use consolidated fetch routine that computes ATR for market data
- document cleanup in duplicate implementations report

## Testing
- `ctest` *(fails: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab17be6e70832aa23c22dcf09040fb