### PR TITLE
Enable CUDA path and compute ATR

### DIFF
--- a/src/app/quantum_signal_bridge.cpp
+++ b/src/app/quantum_signal_bridge.cpp
@@ -48,9 +48,13 @@ static std::vector<sep::connectors::MarketData> fetchRecentMarketData(
         throw std::runtime_error("No historical data returned from OANDA");
     }
 
+    // Calculate ATR values for the candle sequence
+    auto atrs = connector.calculateHistoricalATRs(oanda_candles);
+
     std::vector<sep::connectors::MarketData> market_data;
     market_data.reserve(oanda_candles.size());
-    for (const auto& candle : oanda_candles) {
+    for (size_t i = 0; i < oanda_candles.size(); ++i) {
+        const auto& candle = oanda_candles[i];
         sep::connectors::MarketData md;
         md.instrument = pair_symbol;
         md.timestamp = std::chrono::duration_cast<std::chrono::milliseconds>(
@@ -60,7 +64,7 @@ static std::vector<sep::connectors::MarketData> fetchRecentMarketData(
         md.bid = candle.low;
         md.ask = candle.high;
         md.volume = candle.volume;
-        md.atr = 0.0; // TODO: compute ATR
+        md.atr = (i >= 14 && (i - 14) < atrs.size()) ? atrs[i - 14] : 0.0;
         market_data.push_back(md);
     }
 

--- a/src/app/tick_data_manager.cpp
+++ b/src/app/tick_data_manager.cpp
@@ -427,14 +427,7 @@ void TickDataManager::calculateWindowsCudaAccelerated() {
     }
     
     std::cout << "[TickDataManager] Running CUDA-accelerated window calculations..." << std::endl;
-    
-    // TEMPORARY: Disable CUDA for debugging - use CPU calculation directly
-    std::cout << "[TickDataManager] CUDA temporarily disabled for debugging, using CPU" << std::endl;
-    
-    // Call CPU calculation directly to avoid recursion
-    calculateWindowsCPU();
-    return;
-    
+
     // Convert tick history to CUDA format
     std::vector<cuda::TickData> cuda_ticks;
     cuda_ticks.reserve(tick_history_.size());


### PR DESCRIPTION
## Summary
- remove temporary CPU fallback to enable CUDA window calculations
- compute ATR for recent market data using OANDA candles

## Testing
- `ctest` *(fails: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab17be6e70832aa23c22dcf09040fb