### PR TITLE
Remove testbed paths for production

### DIFF
--- a/src/app/quantum_signal_bridge.cpp
+++ b/src/app/quantum_signal_bridge.cpp
@@ -1038,7 +1038,7 @@ void sep::trading::QuantumSignalBridge::onHigherTimeframeCandle(const Candle& ca
 }
 
 void sep::trading::QuantumSignalBridge::loadOptimalConfig() {
-    const std::string config_path = "/_sep/testbed/optimal_config.json";
+    const std::string config_path = "config/optimal_config.json";
     
     if (!std::filesystem::exists(config_path)) {
         std::cout << "[QuantumSignal] No optimal config found, using defaults" << std::endl;

--- a/src/core/quantum_processor_qfh.h
+++ b/src/core/quantum_processor_qfh.h
@@ -17,8 +17,8 @@ namespace sep::quantum {
 /**
  * QFH-enhanced Quantum Processor
  *
- * Integrates the Quantum Fourier Hierarchy (QFH) approach from the testbed
- * project into the main SEP codebase.
+ * Integrates the Quantum Fourier Hierarchy (QFH) approach into the main SEP
+ * codebase.
  */
 class QuantumProcessorQFHCommon {
 public:

--- a/src/util/interpreter.cpp
+++ b/src/util/interpreter.cpp
@@ -213,7 +213,7 @@ void Interpreter::register_builtins() {
             throw std::runtime_error("Invalid argument type for run_pme_testbed");
         }
         
-        std::string cmd = "cd /_sep/testbed && timeout 30 ./build/examples/pme_testbed_phase2 " + data_file + " 2>/dev/null | tail -5";
+        std::string cmd = "timeout 30 ./build/examples/pme_testbed_phase2 " + data_file + " 2>/dev/null | tail -5";
         
         int result = std::system(cmd.c_str());
         if (result == 0) {
@@ -271,7 +271,7 @@ void Interpreter::register_builtins() {
         std::cout << "DSL: Fetching LIVE data from your OANDA account..." << std::endl;
 
         // Use the production data_downloader with real API credentials
-        std::string cmd = "cd /_sep/testbed && source ./config/OANDA.env && timeout 60 ./build/src/apps/data_downloader";
+        std::string cmd = "source ./config/OANDA.env && timeout 60 ./build/src/apps/data_downloader";
 
         int result = std::system(cmd.c_str());
         if (result == 0) {


### PR DESCRIPTION
## Summary
- Load optimal trading config from repo's config directory instead of testbed path
- Drop hardcoded `/ _sep/testbed` path from DSL's real-data utilities
- Clarify QFH processor documentation for main codebase integration

## Testing
- `ctest` *(fails: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab1894c04c832abc06be9f5f3a67c6