### PR TITLE
chore: remove stub cuda wrapper include

### DIFF
--- a/src/core/cuda_impl.h
+++ b/src/core/cuda_impl.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <cuda_runtime.h>
+#include "cuda_api.hpp"
 
 #include <cstddef>  // For size_t
 #include <cstdio>   // For fprintf
@@ -8,10 +8,8 @@
 
 #include <cstring>  // For strcpy, memcpy, memset
 
-#include "cuda_wrappers.h"  // For proper CUDA type definitions
-
 #ifndef SEP_HD
-#define SEP_HD __host__ __device__
+    #define SEP_HD __host__ __device__
 #endif
 
 // Structure to hold memory copy parameters to avoid similar adjacent parameters
@@ -19,25 +17,25 @@ struct CudaMemcpyParams {
     void* destination;
     const void* source;
     size_t sizeInBytes;
-    sep::cuda::cudaMemcpyKind direction;
-    sep::cuda::cudaStream_t stream;
+    cudaMemcpyKind direction;
+    cudaStream_t stream;
 };
 
 // Helper function for memory copies to avoid parameter similarity issues
-inline sep::cuda::cudaError_t performCudaMemcpyAsync(const CudaMemcpyParams& params) {
+inline cudaError_t performCudaMemcpyAsync(const CudaMemcpyParams& params) {
     // Use the wrapper function to work both with CUDA and stub builds
-    return cudaMemcpyAsync(params.destination, params.source,
-                        params.sizeInBytes, params.direction,
-                        params.stream);
+    return cudaMemcpyAsync(params.destination, params.source, params.sizeInBytes, params.direction,
+                           params.stream);
 }
 
 namespace sep {
 namespace cuda {
 
 // Asynchronous memory copy using the helper function
-inline cudaError_t cudaMemcpyAsyncImpl(void* dst, const void* src, size_t count, sep::cuda::cudaMemcpyKind kind, sep::cuda::cudaStream_t stream) {
+inline cudaError_t cudaMemcpyAsyncImpl(void* dst, const void* src, size_t count,
+                                       cudaMemcpyKind kind, cudaStream_t stream) {
     return performCudaMemcpyAsync({dst, src, count, kind, stream});
 }
 
-} // namespace cuda
-} // namespace sep
+}  // namespace cuda
+}  // namespace sep


### PR DESCRIPTION
## Summary
- replace missing cuda_wrappers include with cuda_api
- use direct CUDA types in cuda_impl helper

## Testing
- `ctest` *(fails: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab1908f114832abb8318f89fa28ca3