### PR TITLE
chore: remove deprecated util headers

### DIFF
--- a/duplicate_implementations_report.md
+++ b/duplicate_implementations_report.md
@@ -41,6 +41,7 @@ This document tracks outstanding code quality concerns in the SEP Engine codebas
 - Removed duplicate market data fetch function and placeholder ATR
   (`src/app/quantum_signal_bridge.cpp`).
 - Unused spdlog isolation stub removed (`src/util/spdlog_isolation.h`).
+- Deprecated header shims consolidated under unified include (`src/util/cuda_safe_includes.h`, `src/util/header_fix.h`, `src/util/force_array.h`, `src/util/functional_safe.h`).
 
 ## Recommendations
 1. Remove remaining hardcoded values via configuration.

--- a/src/util/cuda_safe_includes.h
+++ b/src/util/cuda_safe_includes.h
@@ -1,6 +1,0 @@
-#pragma once
-
-// Deprecated - use the unified header solution
-// CUDA-safe includes that avoid std::array conflicts
-// Always include array first before anything else that might need it
-#include "core/sep_precompiled.h"

--- a/src/util/force_array.h
+++ b/src/util/force_array.h
@@ -1,4 +1,0 @@
-#pragma once
-// Deprecated - use the unified header solution
-// Force include array header to fix GCC 11 functional issues
-#include "core/sep_precompiled.h"

--- a/src/util/functional_safe.h
+++ b/src/util/functional_safe.h
@@ -1,7 +1,0 @@
-#pragma once
-
-// Deprecated - use the unified header solution
-// Safe wrapper for functional header to prevent std::array issues
-// This ensures array is included before functional to satisfy GCC 11 STL dependencies
-
-#include "core/sep_precompiled.h"

--- a/src/util/header_fix.h
+++ b/src/util/header_fix.h
@@ -1,7 +1,0 @@
-#pragma once
-
-// Deprecated - use the unified header solution
-// Universal header fix for GCC 11+ functional header issues
-// Include this file FIRST in any .cpp file that fails with array/functional errors
-
-#include "core/sep_precompiled.h"


### PR DESCRIPTION
## Summary
- remove obsolete util header shims in favor of unified include
- document header cleanup in duplicate implementations report

## Testing
- `ctest` *(fails: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab19c00730832a92a3d907d12bfe17