### PR TITLE
Remove CUDA stubs and update mock inventory

### DIFF
--- a/docs/docs_archive/mock_implementation_inventory.md
+++ b/docs/docs_archive/mock_implementation_inventory.md
@@ -69,7 +69,7 @@ During our initial scan, we identified the following mock implementations and re
 | OandaMarketDataHelper | `src/app/quantum_signal_bridge.cpp` | Helper | Fetches OANDA data with ATR calculation | Resolved |
 | CacheValidator | Referenced in tests | Validation | Validate real data providers | Updated |
 | ServiceInterfaces | `src/app/*` | Interface | Define service contracts | Consolidated |
-| MemoryTierServiceStub | `src/app/MemoryTierService.*` | Service | Mock memory tier management | Removed |
+| CudaApiStubs | `src/core/cuda_api.hpp` | Utility | CPU fallback for CUDA | Removed |
 
 ## Integration with Consolidation Strategy
 

--- a/src/core/cuda_api.hpp
+++ b/src/core/cuda_api.hpp
@@ -1,33 +1,9 @@
 #pragma once
 
-#ifdef SEP_USE_CUDA
-// Only include the real CUDA headers when CUDA support is enabled
+#ifndef SEP_USE_CUDA
+#error "SEP_USE_CUDA must be defined; CUDA support required."
+#endif
+
 #include <cuda_runtime.h>
 #include <device_launch_parameters.h>
-#else
-#include <cstddef>
-#include <cstdlib>
 
-// Minimal stubs so CPU-only builds succeed without CUDA
-using cudaStream_t = void*;
-using cudaError_t = int;
-using cudaMemcpyKind = int;
-constexpr cudaError_t cudaSuccess = 0;
-
-inline const char* cudaGetErrorString(cudaError_t) { return "CUDA disabled"; }
-inline cudaError_t cudaMalloc(void** ptr, size_t size) {
-    *ptr = std::malloc(size);
-    return *ptr ? cudaSuccess : 1;
-}
-inline cudaError_t cudaFree(void* ptr) {
-    std::free(ptr);
-    return cudaSuccess;
-}
-inline cudaError_t cudaMemcpyAsync(void*, const void*, size_t, cudaMemcpyKind, cudaStream_t) {
-    return cudaSuccess;
-}
-inline cudaError_t cudaStreamSynchronize(cudaStream_t) { return cudaSuccess; }
-inline cudaError_t cudaStreamCreate(cudaStream_t*) { return cudaSuccess; }
-inline cudaError_t cudaStreamDestroy(cudaStream_t) { return cudaSuccess; }
-inline cudaError_t cudaMemsetAsync(void*, int, size_t, cudaStream_t) { return cudaSuccess; }
-#endif


### PR DESCRIPTION
## Summary
- remove CPU fallback stubs from `cuda_api.hpp` to require real CUDA headers
- update mock implementation inventory to reflect removal of CUDA stubs

## Testing
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68ab19a800f8832abf06764611291e5c