### PR TITLE
chore: standardize env vars and drop placeholder metrics

### DIFF
--- a/frontend/.env.template
+++ b/frontend/.env.template
@@ -17,8 +17,8 @@
 # =================================================================
 
 # Database API Endpoint (Backend service URL, not direct DB connection)
-REACT_APP_API_BASE_URL=http://localhost:8000/api/v1
-REACT_APP_WS_BASE_URL=ws://localhost:8000/ws
+REACT_APP_API_URL=http://localhost:8000/api/v1
+REACT_APP_WS_URL=ws://localhost:8000/ws
 
 # Database Connection Status Endpoint
 REACT_APP_DB_HEALTH_ENDPOINT=/health/database
@@ -152,8 +152,8 @@ ANALYZE=false
 # =================================================================
 
 # Production API endpoints
-# REACT_APP_API_BASE_URL=https://your-production-api.com/api/v1
-# REACT_APP_WS_BASE_URL=wss://your-production-api.com/ws
+# REACT_APP_API_URL=https://your-production-api.com/api/v1
+# REACT_APP_WS_URL=wss://your-production-api.com/ws
 
 # Production security settings
 # REACT_APP_DEBUG_MODE=false

--- a/frontend/src/context/ManifoldContext.js
+++ b/frontend/src/context/ManifoldContext.js
@@ -29,17 +29,23 @@ export const ManifoldProvider = ({ children }) => {
         identities.set(instrument, []);
       }
       
-      identities.get(instrument).push({
-        timestamp: new Date(timestamp).getTime(),
-        entropy: signal.entropy || 0.5,
-        stability: signal.stability || 0.5,
-        coherence: signal.coherence || 0.5,
-        state: signal.state || 'flux',
-        valkey_key: key,
-        price: signal.price,
-        volume: signal.volume,
-        raw_signal: signal
-      });
+      if (
+        typeof signal.entropy === 'number' &&
+        typeof signal.stability === 'number' &&
+        typeof signal.coherence === 'number'
+      ) {
+        identities.get(instrument).push({
+          timestamp: new Date(timestamp).getTime(),
+          entropy: signal.entropy,
+          stability: signal.stability,
+          coherence: signal.coherence,
+          state: signal.state || 'flux',
+          valkey_key: key,
+          price: signal.price,
+          volume: signal.volume,
+          raw_signal: signal
+        });
+      }
     });
 
     // Sort timelines by timestamp

--- a/frontend/src/context/WebSocketContext.js
+++ b/frontend/src/context/WebSocketContext.js
@@ -7,7 +7,6 @@ const WebSocketContext = createContext(null);
 
 const WS_URL =
   process.env.REACT_APP_WS_URL ||
-  process.env.REACT_APP_WS_BASE_URL ||
   window._env_?.REACT_APP_WS_URL;
 
 export const WebSocketProvider = ({ children }) => {

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,7 +1,7 @@
 // SEP Trading System - API Service
 // Centralized API client for all backend communications
 
-const API_BASE_URL = process.env.REACT_APP_API_URL || process.env.REACT_APP_API_BASE_URL || '';
+const API_BASE_URL = process.env.REACT_APP_API_URL || '';
 
 class APIClient {
   baseURL: string;


### PR DESCRIPTION
## Summary
- remove fallback WebSocket/API env vars and align template
- guard manifold context against missing metrics

## Testing
- `ctest` *(fails: No test configuration file found)*
- `npm test -- --watchAll=false` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab19c00730832a92a3d907d12bfe17