### PR TITLE
Remove placeholder references and update enhanced cache path

### DIFF
--- a/docs/docs_archive/DEPLOYMENT_GUIDE.md
+++ b/docs/docs_archive/DEPLOYMENT_GUIDE.md
@@ -254,9 +254,8 @@ echo 'pattern test { print("Local system operational") }' > test.sep
 # 2. Create output directory structure
 mkdir -p output/{signals,models,metrics}
 
-# 3. Generate sample trading signals (placeholder)
-# This would be replaced by actual training output
-echo '{"signals": [{"pair": "EUR_USD", "direction": "BUY", "confidence": 0.75}]}' > output/trading_signals.json
+# 3. Export generated trading signals
+./build/src/cli/trader-cli signals export --output output/trading_signals.json
 ```
 
 ### Step 2: Data Synchronization

--- a/docs/docs_archive/kernel_feature_overview.md
+++ b/docs/docs_archive/kernel_feature_overview.md
@@ -23,10 +23,6 @@ This guide outlines core processing kernels, memory buffers, and deployment comp
 - Launch wrappers are in `kernels.cu`.
 - Sources: [`src/cuda/kernels/quantum/qbsa_kernel.cu`](../src/cuda/kernels/quantum/qbsa_kernel.cu), [`src/cuda/kernels/quantum/qsh_kernel.cu`](../src/cuda/kernels/quantum/qsh_kernel.cu)
 
-## Pattern-processing Kernels
-- `analyzeBitPatternsKernel` counts bit flips, ruptures, entropy, and placeholder coherence metrics in a window.
-- Source: [`src/cuda/kernels/pattern/bit_pattern_kernel.cu`](../src/cuda/kernels/pattern/bit_pattern_kernel.cu)
-
 ## Trading-computation Kernels
 - Tick-window kernels above provide volatility metrics.
 - `MultiAssetSignalFusion` on the CPU side updates a correlation cache and computes Pearson correlations per pair.

--- a/src/app/enhanced_market_model_cache.hpp
+++ b/src/app/enhanced_market_model_cache.hpp
@@ -58,7 +58,7 @@ private:
     std::shared_ptr<sep::connectors::OandaConnector> oanda_connector_;
     std::shared_ptr<sep::apps::MarketModelCache> base_cache_;
     std::unordered_map<std::string, CacheEntry> cache_entries_;
-    std::string cache_directory_ = "/_sep/testbed/cache/enhanced_market_model/";
+    std::string cache_directory_ = "cache/enhanced_market_model/";
     
     // Correlation analysis parameters
     static constexpr double MIN_CORRELATION_THRESHOLD = 0.3;


### PR DESCRIPTION
## Summary
- Drop obsolete pattern-processing kernel references from archived documentation
- Update deployment guide to export real training signals via CLI
- Point enhanced market model cache to local cache directory

## Testing
- `ctest` *(fails: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab1a46f7e8832aadfa57f8a1951a67