### PR TITLE
docs: resolve duplicate report merge conflict

### DIFF
--- a/duplicate_implementations_report.md
+++ b/duplicate_implementations_report.md
@@ -38,11 +38,8 @@ This document tracks outstanding code quality concerns in the SEP Engine codebas
 - Removed duplicate market data fetch function and placeholder ATR
   (`src/app/quantum_signal_bridge.cpp`).
 - Unused spdlog isolation stub removed (`src/util/spdlog_isolation.h`).
-<<<<<<< .merge_file_wmvsHh
 - Deprecated header shims consolidated under unified include (`src/util/cuda_safe_includes.h`, `src/util/header_fix.h`, `src/util/force_array.h`, `src/util/functional_safe.h`).
-=======
 - Legacy memory tier lookup map removed (`src/util/memory_tier_manager.*`).
->>>>>>> .merge_file_M4fsmQ
 
 ## Recommendations
 1. Remove remaining hardcoded values via configuration.


### PR DESCRIPTION
## Summary
- fix merge conflict markers in `duplicate_implementations_report.md`
- document header shim consolidation and memory tier lookup map removal

## Testing
- No tests were run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68ab1bf8d2d8832a998fbe32d1e136c5