### PR TITLE
Clarify signal threshold documentation

### DIFF
--- a/docs/02_Core_Technology.md
+++ b/docs/02_Core_Technology.md
@@ -65,6 +65,21 @@ const double k1 = 0.3;  // Entropy weight
 const double k2 = 0.2;  // Coherence weight
 ```
 
+### Signal Thresholds
+
+The `PatternMetricEngine` evaluates trading signals using configurable thresholds
+for coherence, stability, and entropy.
+
+```cpp
+struct SignalThresholds {
+    float buy_min_coherence{0.7f};
+    float buy_min_stability{0.6f};
+    float buy_max_entropy{0.3f};
+    float sell_max_stability{0.3f};
+    float sell_min_entropy{0.7f};
+};
+```
+
 ## 5. SEP Framework Theory
 
 The SEP framework provides a new paradigm for understanding reality as a bounded computational system. It is a synthesis of ideas from mathematics, physics, and philosophy, and is built on five core postulates:

--- a/src/core/pattern_metric_engine.cpp
+++ b/src/core/pattern_metric_engine.cpp
@@ -449,7 +449,7 @@ namespace sep::quantum
         }
     }
 
-    // Evaluate signal based on threshold rules defined in docs/TODO.md
+    // Evaluate signal based on threshold rules documented in docs/02_Core_Technology.md
     SignalType PatternMetricEngine::evaluateSignal(const PatternMetrics& m) const
     {
         const auto& th = signal_thresholds_;


### PR DESCRIPTION
## Summary
- Reference proper core technology documentation for signal threshold logic
- Document PatternMetricEngine's signal thresholds for coherence, stability, and entropy

## Testing
- No tests run; documentation-only changes

------
https://chatgpt.com/codex/tasks/task_e_68ab1b83d36c832a9c1aa6097e9b1b1f