### PR TITLE
Remove legacy QuantumSignalBridge stubs

### DIFF
--- a/duplicate_implementations_report.md
+++ b/duplicate_implementations_report.md
@@ -42,6 +42,7 @@ This document tracks outstanding code quality concerns in the SEP Engine codebas
   (`src/app/quantum_signal_bridge.cpp`).
 - Unused spdlog isolation stub removed (`src/util/spdlog_isolation.h`).
 - Deprecated header shims consolidated under unified include (`src/util/cuda_safe_includes.h`, `src/util/header_fix.h`, `src/util/force_array.h`, `src/util/functional_safe.h`).
+- Legacy signal diagnostics and unused state fields removed (`src/app/quantum_signal_bridge.hpp`, `src/app/quantum_signal_bridge.cpp`).
 
 ## Recommendations
 1. Remove remaining hardcoded values via configuration.

--- a/src/app/quantum_signal_bridge.cpp
+++ b/src/app/quantum_signal_bridge.cpp
@@ -550,21 +550,6 @@ double sep::trading::QuantumSignalBridge::calculateTakeProfit(float confidence) 
     return target_pips / 10000.0;  // Convert pips to price distance
 }
 
-void sep::trading::QuantumSignalBridge::debugDataFormat(
-    const std::vector<sep::connectors::MarketData>& history) {
-    if (history.empty())
-        return;
-
-    const auto& latest = history.back();
-    std::cout << "[QuantumSignal] Data format check:" << std::endl;
-    std::cout << "  Instrument: " << latest.instrument << std::endl;
-    std::cout << "  Price (mid): " << latest.mid << std::endl;
-    std::cout << "  Bid: " << latest.bid << std::endl;
-    std::cout << "  Ask: " << latest.ask << std::endl;
-    std::cout << "  ATR: " << latest.atr << std::endl;
-    std::cout << "  History size: " << history.size() << std::endl;
-}
-
 void sep::trading::QuantumSignalBridge::loadPatterns() {
     std::ifstream file(patterns_file_path_);
     if (!file.is_open()) {

--- a/src/app/quantum_signal_bridge.hpp
+++ b/src/app/quantum_signal_bridge.hpp
@@ -183,11 +183,6 @@ public:
     void addManagedPosition(const QuantumTradingSignal& signal, double current_price);
     void updatePositions(const sep::connectors::MarketData& data);
     
-    // Diagnostics
-    const std::vector<uint8_t>& getLastBitPattern() const { return last_bits_; }
-    const sep::quantum::QFHResult& getLastQFHResult() const { return last_qfh_result_; }
-    const sep::quantum::bitspace::QBSAResult& getLastQBSAResult() const { return last_qbsa_result_; }
-
 private:
     // Quantum processors (patent-backed)
     std::unique_ptr<sep::quantum::bitspace::PatternProcessor> pattern_processor_;
@@ -204,11 +199,8 @@ private:
         float convergence_threshold = 1e-6f
     );
     
-    // Data processing (legacy - will be replaced with convergence)
+    // Price data processing
     std::vector<uint8_t> convertPriceToBits(const std::vector<sep::connectors::MarketData>& history);
-    float calculateConfidence(const sep::quantum::QFHResult& qfh_result, const sep::quantum::bitspace::QBSAResult& qbsa_result);
-    float calculateCoherence(const sep::quantum::QFHResult& qfh_result);
-    float calculateStability(const std::vector<sep::connectors::MarketData>& history);
     QuantumTradingSignal::Action determineDirection(
         const sep::quantum::QFHResult& qfh,
         const sep::quantum::bitspace::QBSAResult& qbsa
@@ -222,12 +214,6 @@ private:
     void loadPatterns();
     void savePatterns();
     std::string generatePatternId(const std::string& instrument, uint64_t timestamp);
-    
-    // Debug and diagnostics
-    void debugDataFormat(const std::vector<sep::connectors::MarketData>& history);
-    std::vector<uint8_t> last_bits_;
-    sep::quantum::QFHResult last_qfh_result_;
-    sep::quantum::bitspace::QBSAResult last_qbsa_result_;
     
     // Thread safety
     mutable std::mutex analysis_mutex_;


### PR DESCRIPTION
## Summary
- drop unused diagnostics and state fields from QuantumSignalBridge
- delete unimplemented legacy helper declarations
- document cleanup in duplicate implementations report

## Testing
- No tests run (per instructions to avoid building)


------
https://chatgpt.com/codex/tasks/task_e_68ab1b83d36c832a9c1aa6097e9b1b1f