### PR TITLE
chore: remove redis metrics stub

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -72,7 +72,7 @@ Below is a **structured execution plan** for building a suite of visual aids to 
 ### Summary of Key Repo Citations
 
 * **Frontend API consumption** – The UI uses `/api/market-data`, `/api/performance/current`, `/api/system-status`, and `/api/place-order`, confirming where data comes from.
-* **TODO tasks** – The docs/TODO file lists essential tasks for the UI: rendering tabs, building each component, hooking WebSocket, adding Redis metrics, theme support, tests, and documentation.
+* **TODO tasks** – The docs/TODO file lists essential tasks for the UI: rendering tabs, building each component, hooking WebSocket, adding Valkey metrics, theme support, tests, and documentation.
 * **Metric definitions** – The core engine computes coherence, stability, and entropy by measuring pattern variance, consistency, and entropy of bit patterns.
 * **UI/backend separation** – The external API ensures that the front-end only renders data; all heavy computation happens in the engine.
 

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -83,10 +83,6 @@ class APIClient {
     return this.request('/api/valkey/metrics');
   }
 
-  async getRedisMetrics() {
-    return this.request('/api/metrics/redis');
-  }
-
   async getValkeyStatus() {
     return this.request('/api/valkey/status');
   }


### PR DESCRIPTION
## Summary
- remove unused Redis metrics API wrapper
- document Valkey metrics in TODO roadmap

## Testing
- `ctest` *(fails: No test configuration file found)*
- `npm test -- --watchAll=false` *(fails: No tests found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68ab1ed349e0832ab13cadcb3718319c