### PR TITLE
Remove redundant renormalization and stale CUDA stub reference

### DIFF
--- a/duplicate_implementations_report.md
+++ b/duplicate_implementations_report.md
@@ -47,6 +47,9 @@ This document tracks outstanding code quality concerns in the SEP Engine codebas
 - Unused remote data manager interface and synchronizer stubs removed (`src/core/remote_data_manager.hpp`, `src/core/remote_synchronizer.*`).
 - Outdated Redis metrics API removed to reflect Valkey-only integration (`frontend/src/services/api.ts`).
 
+- Removed redundant amplitude renormalization and stale CUDA stub reference
+  (`src/app/QuantumProcessingService.cpp`, `src/core/cuda_impl.h`).
+
 ## Recommendations
 1. Remove remaining hardcoded values via configuration.
 2. Standardize error handling.

--- a/src/app/QuantumProcessingService.cpp
+++ b/src/app/QuantumProcessingService.cpp
@@ -484,24 +484,11 @@ QuantumState QuantumProcessingService::performAuthenticEvolution(
     for (const auto& amplitude : result.amplitudes) {
         normalization += std::norm(amplitude);
     }
-    
+
     if (normalization > 0.0) {
         double norm_factor = 1.0 / std::sqrt(normalization);
         for (auto& amplitude : result.amplitudes) {
             amplitude *= norm_factor;
-        }
-    }
-    
-    // Normalize amplitudes
-    double totalProb = 0.0;
-    for (const auto& amp : result.amplitudes) {
-        totalProb += std::norm(amp);
-    }
-    
-    if (totalProb > 0.0) {
-        double normFactor = 1.0 / std::sqrt(totalProb);
-        for (auto& amp : result.amplitudes) {
-            amp *= normFactor;
         }
     }
     

--- a/src/core/cuda_impl.h
+++ b/src/core/cuda_impl.h
@@ -23,7 +23,7 @@ struct CudaMemcpyParams {
 
 // Helper function for memory copies to avoid parameter similarity issues
 inline cudaError_t performCudaMemcpyAsync(const CudaMemcpyParams& params) {
-    // Use the wrapper function to work both with CUDA and stub builds
+    // Wrapper that unifies CUDA copy invocation
     return cudaMemcpyAsync(params.destination, params.source, params.sizeInBytes, params.direction,
                            params.stream);
 }


### PR DESCRIPTION
## Summary
- Drop duplicate amplitude renormalization in `QuantumProcessingService::performAuthenticEvolution` for a single normalization pass
- Clarify CUDA copy helper by removing outdated stub build reference
- Document cleanup in duplicate implementations report

## Testing
- `ctest` *(fails: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab20da61fc832a9eaec4e8a0c30d50