### PR TITLE
chore: remove unused weekly fetcher stubs

### DIFF
--- a/duplicate_implementations_report.md
+++ b/duplicate_implementations_report.md
@@ -46,6 +46,7 @@ This document tracks outstanding code quality concerns in the SEP Engine codebas
 - Duplicate CPU window calculation path consolidated into a single helper (`src/app/tick_data_manager.cpp`).
 - Unused remote data manager interface and synchronizer stubs removed (`src/core/remote_data_manager.hpp`, `src/core/remote_synchronizer.*`).
 - Outdated Redis metrics API removed to reflect Valkey-only integration (`frontend/src/services/api.ts`).
+- Unimplemented WeeklyDataFetcher configuration and cache helpers removed (`src/core/weekly_data_fetcher.*`).
 
 ## Recommendations
 1. Remove remaining hardcoded values via configuration.

--- a/src/core/weekly_data_fetcher.cpp
+++ b/src/core/weekly_data_fetcher.cpp
@@ -8,8 +8,6 @@
 #include <algorithm>
 #include <curl/curl.h>
 #include <cstdlib>
-#include <fstream>
-#include <sstream>
 #include <nlohmann/json.hpp>
 
 using namespace sep::train;
@@ -189,22 +187,14 @@ DataFetchResult WeeklyDataFetcher::fetchInstrument(const std::string& instrument
 
 std::vector<DataFetchResult> WeeklyDataFetcher::fetchSelected(const std::vector<std::string>& instruments) {
     std::vector<DataFetchResult> results;
-    
+
     for (const auto& instrument : instruments) {
         if (isValidInstrument(instrument)) {
             results.push_back(fetchInstrument(instrument));
         }
     }
-    
-    return results;
-}
 
-bool WeeklyDataFetcher::validateCachedData(const std::string& instrument) const {
-    std::string cache_path = getCachePath(instrument, "M1");
-    
-    // Check if file exists and is recent
-    // Simplified validation for now
-    return true;
+    return results;
 }
 
 std::string WeeklyDataFetcher::getCachePath(const std::string& instrument,

--- a/src/core/weekly_data_fetcher.hpp
+++ b/src/core/weekly_data_fetcher.hpp
@@ -46,35 +46,17 @@ public:
 
     // Configuration
     bool configure(const DataFetchConfig& config);
-    bool loadConfigFromFile(const std::string& config_path);
-    bool saveConfigToFile(const std::string& config_path) const;
-    
+
     // Main fetch operations
     std::vector<DataFetchResult> fetchAllInstruments();
     DataFetchResult fetchInstrument(const std::string& instrument);
     std::vector<DataFetchResult> fetchSelected(const std::vector<std::string>& instruments);
-    
-    // Granularity-specific fetching
-    DataFetchResult fetchInstrumentGranularity(const std::string& instrument, 
-                                               const std::string& granularity);
-    
-    // Parallel fetching
-    std::vector<DataFetchResult> fetchInstrumentsParallel(const std::vector<std::string>& instruments);
-    
-    // Cache management
-    bool validateCachedData(const std::string& instrument) const;
-    bool clearCachedData(const std::string& instrument = "");
-    std::map<std::string, std::chrono::system_clock::time_point> getCacheStatus() const;
-    
+
     // Status and monitoring
     bool isFetchInProgress() const;
     double getFetchProgress() const;
     std::string getCurrentOperation() const;
     std::vector<std::string> getSupportedInstruments() const;
-    
-    // Data validation
-    bool validateFetchedData(const DataFetchResult& result) const;
-    std::map<std::string, size_t> getDataStatistics() const;
     
 private:
     DataFetchConfig config_;
@@ -85,41 +67,22 @@ private:
     
     // OANDA API interface
     bool initializeOandaAPI();
-    std::string makeOandaRequest(const std::string& endpoint, 
-                                const std::map<std::string, std::string>& params) const;
-    
-    // Data processing
-    bool processCandleData(const std::string& json_response,
-                          const std::string& instrument,
-                          const std::string& granularity,
-                          const std::string& cache_path) const;
-    
+
     // Cache operations
-    std::string getCachePath(const std::string& instrument, 
+    std::string getCachePath(const std::string& instrument,
                             const std::string& granularity) const;
-    bool ensureCacheDirectory() const;
-    bool compressDataFile(const std::string& file_path) const;
-    
+
     // Time utilities
-    std::string formatTimeForAPI(const std::chrono::system_clock::time_point& time) const;
     std::chrono::system_clock::time_point getStartTime() const;
     std::chrono::system_clock::time_point getEndTime() const;
-    
-    // Error handling
-    void logError(const std::string& operation, const std::string& error) const;
-    void logSuccess(const std::string& operation, const DataFetchResult& result) const;
-    
+
     // Validation utilities
     bool isValidInstrument(const std::string& instrument) const;
-    bool isValidGranularity(const std::string& granularity) const;
-    size_t validateCandleCount(const std::string& cache_path) const;
 };
 
 // Utility functions for external use
 std::vector<std::string> getStandardForexPairs();
 std::vector<std::string> getStandardGranularities();
-bool isMarketOpen();
-std::chrono::system_clock::time_point getLastMarketClose();
 
 } // namespace train
 } // namespace sep


### PR DESCRIPTION
## Summary
- prune unused configuration, cache, and validation methods from WeeklyDataFetcher
- document removal of WeeklyDataFetcher stubs in duplicate implementations report

## Testing
- `ctest` *(fails: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab20da61fc832a9eaec4e8a0c30d50