### PR TITLE
Capture trade updates in WebSocket context

### DIFF
--- a/duplicate_implementations_report.md
+++ b/duplicate_implementations_report.md
@@ -46,6 +46,7 @@ This document tracks outstanding code quality concerns in the SEP Engine codebas
 - Duplicate CPU window calculation path consolidated into a single helper (`src/app/tick_data_manager.cpp`).
 - Unused remote data manager interface and synchronizer stubs removed (`src/core/remote_data_manager.hpp`, `src/core/remote_synchronizer.*`).
 - Outdated Redis metrics API removed to reflect Valkey-only integration (`frontend/src/services/api.ts`).
+- Trade update handler now stores recent updates instead of logging to console (`frontend/src/context/WebSocketContext.js`).
 
 ## Recommendations
 1. Remove remaining hardcoded values via configuration.

--- a/frontend/src/context/WebSocketContext.js
+++ b/frontend/src/context/WebSocketContext.js
@@ -18,6 +18,7 @@ export const WebSocketProvider = ({ children }) => {
   const [marketData, setMarketData] = useState({});
   const [systemStatus, setSystemStatus] = useState({});
   const [tradingSignals, setTradingSignals] = useState([]);
+  const [tradeUpdates, setTradeUpdates] = useState([]);
   const [performanceData, setPerformanceData] = useState({});
   const [systemMetrics, setSystemMetrics] = useState({});
   
@@ -26,6 +27,10 @@ export const WebSocketProvider = ({ children }) => {
   const [signalHistory, setSignalHistory] = useState([]);
   const [valkeyMetrics, setValkeyMetrics] = useState({});
   const [livePatterns, setLivePatterns] = useState({});
+  const [, setManifoldStream] = useState({});
+  const [, setPinStates] = useState(new Map());
+  const [, setSignalEvolution] = useState(new Map());
+  const [, setBackwardsDerivations] = useState(new Map());
   
   // Connection management
   const reconnectTimeoutRef = useRef(null);
@@ -79,8 +84,12 @@ export const WebSocketProvider = ({ children }) => {
     },
     
     trades: (data) => {
-      // Handle trade execution updates
-      console.log('Trade update:', data);
+      if (data) {
+        setTradeUpdates(prev => {
+          const updates = [data, ...prev];
+          return updates.slice(0, 100);
+        });
+      }
     },
     
     // New handlers for Valkey/Redis data streams
@@ -477,6 +486,7 @@ export const WebSocketProvider = ({ children }) => {
     tradingSignals,
     performanceData,
     systemMetrics,
+    tradeUpdates,
     
     // Valkey/Redis quantum data
     quantumSignals,
@@ -527,6 +537,11 @@ export const useSystemStatus = () => {
 export const usePerformanceData = () => {
   const { performanceData } = useWebSocket();
   return performanceData;
+};
+
+export const useTradeUpdates = () => {
+  const { tradeUpdates } = useWebSocket();
+  return tradeUpdates;
 };
 
 export { WebSocketContext };


### PR DESCRIPTION
## Summary
- Track trade execution updates in the WebSocket context instead of logging them
- Expose recent trade updates through context and `useTradeUpdates` hook
- Document cleanup in duplicate implementations report

## Testing
- `npm test -- --watchAll=false --passWithNoTests`
- `npx eslint src/context/WebSocketContext.js`
- `ctest` *(fails: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab20da61fc832a9eaec4e8a0c30d50