### PR TITLE
chore: prune legacy helpers

### DIFF
--- a/duplicate_implementations_report.md
+++ b/duplicate_implementations_report.md
@@ -46,6 +46,8 @@ This document tracks outstanding code quality concerns in the SEP Engine codebas
 - Duplicate CPU window calculation path consolidated into a single helper (`src/app/tick_data_manager.cpp`).
 - Unused remote data manager interface and synchronizer stubs removed (`src/core/remote_data_manager.hpp`, `src/core/remote_synchronizer.*`).
 - Outdated Redis metrics API removed to reflect Valkey-only integration (`frontend/src/services/api.ts`).
+- Redundant Valkey metric fallback helper removed (`src/util/interpreter.cpp`).
+- Unused prototype market data fetcher removed (`src/app/quantum_signal_bridge.cpp`).
 
 ## Recommendations
 1. Remove remaining hardcoded values via configuration.

--- a/src/app/quantum_signal_bridge.cpp
+++ b/src/app/quantum_signal_bridge.cpp
@@ -54,61 +54,7 @@ void from_json(const json& j, Candle& c) {
     }
 }
 
-namespace {
-std::vector<sep::connectors::MarketData> fetchRecentMarketData(
-    sep::connectors::OandaConnector& connector, const std::string& pair_symbol, size_t hours_back) {
-    using namespace std::chrono;
 
-    auto now = system_clock::now();
-    auto start_time = now - hours(hours_back);
-
-    auto formatTimestamp = [](const system_clock::time_point& tp) {
-        auto time_t = system_clock::to_time_t(tp);
-        std::stringstream ss;
-        ss << std::put_time(std::gmtime(&time_t), "%Y-%m-%dT%H:%M:%SZ");
-        return ss.str();
-    };
-
-    std::string from_str = formatTimestamp(start_time);
-    std::string to_str = formatTimestamp(now);
-
-    auto oanda_candles = connector.getHistoricalData(pair_symbol, "M1", from_str, to_str);
-    if (oanda_candles.empty()) {
-        throw std::runtime_error("No historical data returned from OANDA");
-    }
-
-    std::vector<sep::connectors::MarketData> market_data;
-    market_data.reserve(oanda_candles.size());
-
-    double atr = 0.0;
-    const size_t period = 14;
-    for (const auto& candle : oanda_candles) {
-        sep::connectors::MarketData md;
-        md.instrument = pair_symbol;
-        md.timestamp =
-            duration_cast<milliseconds>(parseTimestamp(candle.time).time_since_epoch()).count();
-        md.mid = candle.close;
-        md.bid = candle.low;
-        md.ask = candle.high;
-        md.volume = candle.volume;
-
-        double tr;
-        if (market_data.empty()) {
-            tr = candle.high - candle.low;
-        } else {
-            double prev_close = market_data.back().mid;
-            tr = std::max({candle.high - candle.low, std::abs(candle.high - prev_close),
-                           std::abs(candle.low - prev_close)});
-        }
-        atr = market_data.empty() ? tr
-                                  : atr + (tr - atr) / std::min(period, market_data.size() + 1.0);
-        md.atr = atr;
-        market_data.push_back(md);
-    }
-
-    return market_data;
-}
-}  // anonymous namespace
 
 namespace sep::trading {
 

--- a/src/util/interpreter.cpp
+++ b/src/util/interpreter.cpp
@@ -47,24 +47,6 @@ namespace {
         }
     }
     
-    // Helper function to get trading data from Valkey
-    double get_valkey_trading_metric(const std::string& metric_key, double fallback_value = 0.0) {
-        try {
-            auto redis_manager = sep::persistence::createRedisManager();
-            if (!redis_manager || !redis_manager->isConnected()) {
-                std::cout << "ℹ️  INFO: Valkey not connected, returning fallback for " << metric_key << std::endl;
-                return fallback_value;
-            }
-
-            // Real trading metrics retrieval is not yet implemented.
-            // Avoid generating synthetic values to prevent misleading data.
-        } catch (const std::exception& e) {
-            std::cout << "⚠️  Warning: Error accessing Valkey for " << metric_key << ": " << e.what() << std::endl;
-        }
-
-        return fallback_value;
-    }
-    
     // Helper function to check market session status using real-time data
     bool is_market_open() {
         try {


### PR DESCRIPTION
## Summary
- remove redundant Valkey trading metric fallback helper
- drop unused prototype market data fetcher
- document cleanup in duplicate implementation report

## Testing
- `ctest -N`


------
https://chatgpt.com/codex/tasks/task_e_68ab215d1354832a948959029fba0536