### PR TITLE
Clean up configuration placeholders and obsolete comment

### DIFF
--- a/frontend/.env.template
+++ b/frontend/.env.template
@@ -17,8 +17,8 @@
 # =================================================================
 
 # Database API Endpoint (Backend service URL, not direct DB connection)
-REACT_APP_API_URL=http://localhost:8000/api/v1
-REACT_APP_WS_URL=ws://localhost:8000/ws
+REACT_APP_API_URL=
+REACT_APP_WS_URL=
 
 # Database Connection Status Endpoint
 REACT_APP_DB_HEALTH_ENDPOINT=/health/database

--- a/src/app/QuantumProcessingService.cpp
+++ b/src/app/QuantumProcessingService.cpp
@@ -155,9 +155,6 @@ Result<QuantumState> QuantumProcessingService::evolveQuantumState(
 Result<QuantumState> QuantumProcessingService::runQuantumPipeline(const QuantumState& state) {
     REQUIRE_INIT();
     try {
-        // Skip initialization check temporarily to resolve diamond inheritance issue
-        // TODO: Implement proper initialization check without causing inheritance ambiguity
-        
         // Run full pipeline: QBSA -> QFH -> Coherence -> Stability -> Evolution
         
         // Step 1: QBSA


### PR DESCRIPTION
## Summary
- Remove hardcoded API endpoints from frontend environment template to prevent unintended mock connections
- Drop obsolete initialization comment in QuantumProcessingService

## Testing
- `ctest` *(fails: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab22376b84832abd9d1939babcfb96