### PR TITLE
Handle unimplemented CUDA path in MemoryTierManager

### DIFF
--- a/duplicate_implementations_report.md
+++ b/duplicate_implementations_report.md
@@ -50,6 +50,7 @@ This document tracks outstanding code quality concerns in the SEP Engine codebas
 - Unimplemented WeeklyDataFetcher configuration and cache helpers removed (`src/core/weekly_data_fetcher.*`).
 - Removed redundant amplitude renormalization and stale CUDA stub reference
   (`src/app/QuantumProcessingService.cpp`, `src/core/cuda_impl.h`).
+- Unimplemented CUDA path in MemoryTierManager now returns `NOT_IMPLEMENTED` instead of logging (`src/util/memory_tier_manager.cpp`).
 
 ## Recommendations
 1. Remove remaining hardcoded values via configuration.

--- a/src/util/memory_tier_manager.cpp
+++ b/src/util/memory_tier_manager.cpp
@@ -677,14 +677,10 @@ sep::SEPResult MemoryTierManager::processMemoryBlocks(void *input_data, void *ou
             }
         }
 
-        // If CUDA stream is provided and we have CUDA support in the future,
-        // we can dispatch to GPU kernels here
+        // Explicitly report lack of CUDA processing support
         if (stream && proc_config && proc_config->enable_cuda)
         {
-            // Future: Launch CUDA kernels for parallel processing
-            // For now, just log that CUDA was requested but not available
-            std::cerr << "[MemoryTierManager] CUDA processing requested but not implemented yet"
-                      << std::endl;
+            return sep::SEPResult::NOT_IMPLEMENTED;
         }
 
         return sep::SEPResult::SUCCESS;


### PR DESCRIPTION
## Summary
- explicitly return `NOT_IMPLEMENTED` when CUDA processing is requested but unsupported in MemoryTierManager
- note cleanup in duplicate implementations report

## Testing
- `ctest` *(fails: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab22376b84832abd9d1939babcfb96