### PR TITLE
Clean merge remnants and align quantum signal docs

### DIFF
--- a/duplicate_implementations_report.md
+++ b/duplicate_implementations_report.md
@@ -50,16 +50,13 @@ This document tracks outstanding code quality concerns in the SEP Engine codebas
 - Duplicate CPU window calculation path consolidated into a single helper (`src/app/tick_data_manager.cpp`).
 - Unused remote data manager interface and synchronizer stubs removed (`src/core/remote_data_manager.hpp`, `src/core/remote_synchronizer.*`).
 - Outdated Redis metrics API removed to reflect Valkey-only integration (`frontend/src/services/api.ts`).
-<<<<<<< .merge_file_648rKg
 - Unused QuantumProcessingService and duplicate service-layer types removed (`src/app/QuantumProcessingService.*`, `src/app/QuantumTypes.h`, `src/app/PatternTypes.h`, `tests/app/quantum_processing_service_guard_test.cpp`).
 - Trade update handler now stores recent updates instead of logging to console (`frontend/src/context/WebSocketContext.js`).
 - Unimplemented WeeklyDataFetcher configuration and cache helpers removed (`src/core/weekly_data_fetcher.*`).
 - Removed redundant amplitude renormalization and stale CUDA stub reference
   (`src/app/QuantumProcessingService.cpp`, `src/core/cuda_impl.h`).
-=======
 - Redundant Valkey metric fallback helper removed (`src/util/interpreter.cpp`).
 - Unused prototype market data fetcher removed (`src/app/quantum_signal_bridge.cpp`).
->>>>>>> .merge_file_PJOpw2
 
 ## Recommendations
 1. Remove remaining hardcoded values via configuration.

--- a/src/app/quantum_signal_bridge.cpp
+++ b/src/app/quantum_signal_bridge.cpp
@@ -54,10 +54,6 @@ void from_json(const json& j, Candle& c) {
     }
 }
 
-<<<<<<< .merge_file_64S2FF
-=======
-
->>>>>>> .merge_file_7S4Yg5
 
 namespace sep::trading {
 

--- a/src/app/quantum_signal_bridge.hpp
+++ b/src/app/quantum_signal_bridge.hpp
@@ -48,7 +48,7 @@ struct QuantumIdentifiers {
 
 /**
  * Multi-timeframe confirmation result
- * Used for triple confirmation logic from testbed analysis
+ * Used for triple confirmation logic based on multi-timeframe analysis
  */
 struct MultiTimeframeConfirmation {
     bool m5_confirms = false;
@@ -116,7 +116,7 @@ public:
     // Real-time signal map updates
     void updateSignalMap(int timeframe_minutes, const std::string& timestamp, const QuantumTradingSignal& signal);
     
-    // Core analysis pipeline (adapted from testbed)
+    // Core analysis pipeline for production use
     std::map<std::string, QuantumTradingSignal> runAnalysisPipeline(
         const std::vector<Candle>& candles, 
         const std::string& timeframe_name = "M1");


### PR DESCRIPTION
## Summary
- Strip leftover merge markers from `QuantumSignalBridge` implementation
- Clarify multi-timeframe comments and promote production analysis wording
- Merge conflicting entries in duplicate implementations report

## Testing
- `ctest` *(fails: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab22e3ffd0832a91da37ca240ba808