### PR TITLE
Clean merge artifacts in quantum_signal_bridge and docs

### DIFF
--- a/duplicate_implementations_report.md
+++ b/duplicate_implementations_report.md
@@ -51,16 +51,12 @@ This document tracks outstanding code quality concerns in the SEP Engine codebas
 - Unused remote data manager interface and synchronizer stubs removed (`src/core/remote_data_manager.hpp`, `src/core/remote_synchronizer.*`).
 - Obsolete RemoteDataManager implementation and TrainingCoordinator stub removed (`src/core/RemoteDataManager.h`, `src/core/remote_data_manager.cpp`, `src/core/TrainingCoordinator.h`).
 - Outdated Redis metrics API removed to reflect Valkey-only integration (`frontend/src/services/api.ts`).
-<<<<<<< .merge_file_648rKg
 - Unused QuantumProcessingService and duplicate service-layer types removed (`src/app/QuantumProcessingService.*`, `src/app/QuantumTypes.h`, `src/app/PatternTypes.h`, `tests/app/quantum_processing_service_guard_test.cpp`).
 - Trade update handler now stores recent updates instead of logging to console (`frontend/src/context/WebSocketContext.js`).
 - Unimplemented WeeklyDataFetcher configuration and cache helpers removed (`src/core/weekly_data_fetcher.*`).
-- Removed redundant amplitude renormalization and stale CUDA stub reference
-  (`src/app/QuantumProcessingService.cpp`, `src/core/cuda_impl.h`).
-=======
+- Removed redundant amplitude renormalization and stale CUDA stub reference (`src/app/QuantumProcessingService.cpp`, `src/core/cuda_impl.h`).
 - Redundant Valkey metric fallback helper removed (`src/util/interpreter.cpp`).
 - Unused prototype market data fetcher removed (`src/app/quantum_signal_bridge.cpp`).
->>>>>>> .merge_file_PJOpw2
 
 ## Recommendations
 1. Remove remaining hardcoded values via configuration.

--- a/src/app/quantum_signal_bridge.cpp
+++ b/src/app/quantum_signal_bridge.cpp
@@ -54,10 +54,6 @@ void from_json(const json& j, Candle& c) {
     }
 }
 
-<<<<<<< .merge_file_64S2FF
-=======
-
->>>>>>> .merge_file_7S4Yg5
 
 namespace sep::trading {
 


### PR DESCRIPTION
## Summary
- Remove leftover merge conflict markers in quantum_signal_bridge.cpp
- Consolidate duplicate cleanup report entries and resolve merge markers

## Testing
- `ctest` *(fails: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab23a4fa28832aa9f7fca05f97f1b3