### PR TITLE
refactor: remove unused websocket placeholders

### DIFF
--- a/frontend/src/context/WebSocketContext.js
+++ b/frontend/src/context/WebSocketContext.js
@@ -27,10 +27,6 @@ export const WebSocketProvider = ({ children }) => {
   const [signalHistory, setSignalHistory] = useState([]);
   const [valkeyMetrics, setValkeyMetrics] = useState({});
   const [livePatterns, setLivePatterns] = useState({});
-  const [, setManifoldStream] = useState({});
-  const [, setPinStates] = useState(new Map());
-  const [, setSignalEvolution] = useState(new Map());
-  const [, setBackwardsDerivations] = useState(new Map());
   
   // Connection management
   const reconnectTimeoutRef = useRef(null);


### PR DESCRIPTION
## Summary
- remove unused websocket placeholder states

## Testing
- `npm test -- --watchAll=false --passWithNoTests`
- `ctest` *(fails: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab242bf2fc832a8e534865d7c597fe