### PR TITLE
Replace Redis references with Valkey and drop unused API alias

### DIFF
--- a/docs/00_SEP_PROFESSIONAL_SYSTEM_OVERVIEW.md
+++ b/docs/00_SEP_PROFESSIONAL_SYSTEM_OVERVIEW.md
@@ -42,7 +42,7 @@ The system implements a **three-tier professional architecture**:
 | **Trading Service API** | Python/Flask | REST API, system integration | ✅ Operational |
 | **WebSocket Service** | Python/WebSockets | Real-time data streaming | ✅ Operational |
 | **Web Dashboard** | React/TypeScript | Management interface | ✅ Operational |
-| **Redis Cache** | Redis 7 | Session storage, caching | ✅ Operational |
+| **Valkey Cache** | Valkey (Redis-compatible) | Session storage, caching | ✅ Operational |
 
 ### Service Architecture
 
@@ -84,10 +84,10 @@ The system implements a **three-tier professional architecture**:
 
 ```yaml
 Services:
-- redis (6380): Redis cache and session storage
 - trading-backend (5000): Flask API service
-- websocket-service (8765): Real-time data service  
+- websocket-service (8765): Real-time data service
 - frontend (80/443): Nginx-served React application
+- external valkey: Valkey key-value store (configure `VALKEY_URL`)
 
 Network: sep-network (172.25.0.0/16)
 Volumes: Local bind mounts for development
@@ -96,11 +96,11 @@ Volumes: Local bind mounts for development
 #### Production Environment (`docker-compose.production.yml`)
 
 ```yaml
-Services: 
-- redis (6380): Redis with persistent storage
+Services:
 - trading-backend (5000): Production Flask API
 - websocket-service (8765): Production WebSocket service
 - frontend (80/443): Production web application
+- external valkey: Managed Valkey instance (set `VALKEY_URL`)
 
 Network: sep-network (172.25.0.0/16)
 Volumes: Persistent volume storage on /mnt/volume_nyc3_01
@@ -161,7 +161,7 @@ The system features a sophisticated **CLI Bridge** (`scripts/cli_bridge.py`) tha
 ```
 Market Data → SEP Engine → Trading Decisions
      ↓              ↓            ↓
-WebSocket ← Redis Cache ← Trading Service API
+WebSocket ← Valkey Store ← Trading Service API
      ↓
 Web Dashboard (Real-time Updates)
 ```
@@ -179,7 +179,7 @@ Web Dashboard (Real-time Updates)
 - **API Key Authentication**: Secure service-to-service communication
 - **CORS Configuration**: Professional cross-origin resource sharing
 - **Rate Limiting**: API endpoint protection
-- **Session Management**: Redis-based session handling
+- **Session Management**: Valkey-based session handling
 
 ### Monitoring and Observability
 - **Health Checks**: Comprehensive service health monitoring

--- a/docs/01_DEPLOYMENT_INTEGRATION_GUIDE.md
+++ b/docs/01_DEPLOYMENT_INTEGRATION_GUIDE.md
@@ -55,7 +55,7 @@ This guide provides detailed instructions for deploying and integrating the SEP 
 ### Software Dependencies
 ```bash
 # Core dependencies (handled by Docker)
-- Redis 7-alpine
+- Valkey (Redis-compatible)
 - Python 3.11+
 - Node.js 18+ (for frontend builds)
 - Nginx (for frontend serving)
@@ -110,7 +110,7 @@ mkdir -p {data,logs,config}
 # Configure environment
 cat > .sep-config.env << EOF
 FLASK_ENV=development
-REDIS_URL=redis://redis:6380/0
+VALKEY_URL=redis://valkey:6380/0
 SEP_CONFIG_PATH=/app/config
 PYTHONPATH=/app
 PORT=5000
@@ -284,7 +284,7 @@ Key Features:
 - Local bind mounts for development
 - Hot-reload support
 - Development environment variables
-- Local Redis without persistence requirement
+- Optional Valkey without persistence requirement
 - Direct port mapping for debugging
 ```
 
@@ -304,7 +304,7 @@ Key Features:
 ```bash
 # Core configuration
 FLASK_ENV=production
-REDIS_URL=redis://redis:6380/0
+VALKEY_URL=redis://valkey:6380/0
 SEP_CONFIG_PATH=/app/config
 PYTHONPATH=/app
 PORT=5000
@@ -332,7 +332,7 @@ REACT_APP_ENVIRONMENT=production
 
 #### WebSocket Service Environment
 ```bash
-REDIS_URL=redis://redis:6380/0
+VALKEY_URL=redis://valkey:6380/0
 WS_HOST=0.0.0.0
 WS_PORT=8765
 LOG_LEVEL=INFO
@@ -413,7 +413,6 @@ networks:
         - subnet: 172.25.0.0/16
 
 # Service discovery (internal)
-redis:6380           # Redis cache
 trading-backend:5000 # API service
 websocket-service:8765 # WebSocket service
 ```
@@ -450,7 +449,7 @@ websocket-service:8765 # WebSocket service
 curl -f http://[host]:5000/api/health    # Backend health
 curl -f http://[host]/health             # Frontend health  
 nc -z [host] 8765                        # WebSocket connectivity
-redis-cli -h [host] -p 6380 ping        # Redis health
+valkey-cli -h [host] -p 6380 ping       # Valkey health
 ```
 
 ### Log Management
@@ -463,9 +462,8 @@ redis-cli -h [host] -p 6380 ping        # Redis health
 
 # Container logs
 docker logs sep-trading-backend
-docker logs sep-websocket  
+docker logs sep-websocket
 docker logs sep-frontend
-docker logs sep-redis
 ```
 
 ### Performance Monitoring
@@ -494,7 +492,7 @@ docker network ls
 docker network inspect sep_sep-network
 
 # Check port conflicts
-netstat -tulpn | grep -E "(5000|8765|6380|80|443)"
+netstat -tulpn | grep -E "(5000|8765|80|443)"
 ```
 
 #### Database Connection Issues
@@ -547,7 +545,6 @@ docker-compose -f docker-compose.production.yml up -d
 #### Data Recovery
 ```bash
 # Backup important data
-docker exec sep-redis redis-cli BGSAVE
 tar -czf backup-$(date +%Y%m%d).tar.gz data/ logs/ config/
 
 # Restore from backup
@@ -575,7 +572,7 @@ frontend/src/api/custom/       # Custom API clients
 - Container orchestration (Kubernetes/Swarm)
 - Load balancer configuration
 - Database sharding strategies
-- Redis cluster setup
+- Valkey cluster setup
 - CDN integration for frontend assets
 ```
 

--- a/docs/01_System_Architecture.md
+++ b/docs/01_System_Architecture.md
@@ -33,7 +33,7 @@ The system processes both real-time and historical market data. The core of the 
 The system uses a robust, enterprise-grade data layer:
 
 *   **PostgreSQL + TimescaleDB:** The primary database for time-series market data.
-*   **Redis:** A high-speed, in-memory cache for frequently accessed data.
+*   **Valkey:** A high-speed, Redis-compatible in-memory cache for frequently accessed data.
 *   **HWLOC:** Used to enable NUMA-aware processing for performance optimization.
 
 ## 4. Cloud Deployment and Architecture

--- a/docs/SEPEngine_WP.md
+++ b/docs/SEPEngine_WP.md
@@ -74,7 +74,7 @@ design and is pivotal for scalability and testability of the engine .
 3. Time-Anchored Identity Manifold (Valkey Database)
 At the heart of SEP’s architecture is the Valkey database, which serves as a time-anchored manifold of
 identities in the system. In practical terms, Valkey (a high-performance key–value store akin to an advanced
-Redis) is used as the Long-Term Memory (LTM) tier to persistently store patterns that have proven stable
+Valkey (Redis-compatible) is used as the Long-Term Memory (LTM) tier to persistently store patterns that have proven stable
 and important . Each identity in this context refers to a distinct emergent pattern or data entity that the
 engine is tracking. Identities could represent, for example, a candidate market regime pattern or a learned
 signal feature. As time progresses, each identity’s state is captured at discrete intervals (e.g. each tick or

--- a/docs/docs_archive/QUICKSTART.md
+++ b/docs/docs_archive/QUICKSTART.md
@@ -166,7 +166,7 @@ curl -X POST http://localhost:8080/api/data/reload  # Reload configuration
 ### Professional State Management
 - **Persistent Configuration**: JSON-based pair and system settings
 - **Hot-Swappable Updates**: Real-time configuration changes
-- **Enterprise Data Layer**: PostgreSQL + TimescaleDB + Redis
+- **Enterprise Data Layer**: PostgreSQL + TimescaleDB + Valkey
 
 ### Remote Execution System
 - **Lightweight Trading Service**: `scripts/trading_service.py`

--- a/docs/docs_archive/kernel_feature_overview.md
+++ b/docs/docs_archive/kernel_feature_overview.md
@@ -37,7 +37,7 @@ This guide outlines core processing kernels, memory buffers, and deployment comp
 - Source: [`_sep/testbed/cuda_marketdata_harness.cu`](../_sep/testbed/cuda_marketdata_harness.cu)
 
 ## Hybrid Architecture and Data Flow
-- `sync_to_droplet.sh` ships outputs, configs, and models to the remote droplet while excluding `.env` files and optionally exporting Redis snapshots.
+- `sync_to_droplet.sh` ships outputs, configs, and models to the remote droplet while excluding `.env` files and optionally exporting Valkey snapshots.
 - Source: [`scripts/sync_to_droplet.sh`](../scripts/sync_to_droplet.sh)
 
 ## Deployment and Hardening

--- a/docs/docs_archive/sync-workflow.md
+++ b/docs/docs_archive/sync-workflow.md
@@ -8,9 +8,9 @@ After running local CUDA training, push the generated metrics and models to the 
 
 This script copies the latest outputs to `/opt/sep-trader/data` on the droplet.
 
-## Import Metrics into Redis
+## Import Metrics into Valkey
 
-Use SSH to load the newest metric snapshot into Redis on the droplet. Replace `<PAIR>` with the currency pair you trained:
+Use SSH to load the newest metric snapshot into Valkey on the droplet. Replace `<PAIR>` with the currency pair you trained:
 
 ```bash
 ssh root@YOUR_DROPLET_IP "cd /opt/sep-trader/sep-trader && ./build/src/cli/trader-cli data import /opt/sep-trader/data/latest_metrics_<PAIR>.rdb"
@@ -26,11 +26,11 @@ ssh root@YOUR_DROPLET_IP "cd /opt/sep-trader/sep-trader && ./build/src/cli/trade
   ```
   Confirm `latest_metrics_<PAIR>.rdb` appears with the correct pair name.
 
-### Redis connection errors
-- The import command reports issues like `Connection refused` or `Unable to reach Redis` when the Redis service is offline.
-- Check Redis status and restart if needed:
+### Valkey connection errors
+- The import command reports issues like `Connection refused` or `Unable to reach Valkey` when the Valkey service is offline.
+- Check Valkey status and restart if needed:
   ```bash
-  ssh root@YOUR_DROPLET_IP "docker-compose ps redis"
-  ssh root@YOUR_DROPLET_IP "docker-compose restart redis"
+  ssh root@YOUR_DROPLET_IP "docker-compose ps valkey"
+  ssh root@YOUR_DROPLET_IP "docker-compose restart valkey"
   ```
-- Run `redis-cli ping` to confirm connectivity before re-running the import.
+- Run `valkey-cli ping` to confirm connectivity before re-running the import.

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -264,9 +264,6 @@ export const {
   isAuthenticated,
 } = apiClient as any;
 
-// Add alias for getConfiguration to maintain compatibility
-export const getConfiguration = apiClient.getConfig.bind(apiClient);
-
 export { apiClient };
 export default apiClient;
 


### PR DESCRIPTION
## Summary
- remove unused `getConfiguration` alias from frontend API client
- update documentation to reflect Valkey usage instead of Redis and refresh deployment steps

## Testing
- `CI=true npm test --prefix frontend -- --watchAll=false` *(fails: No tests found)*
- `ctest` *(fails: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab242bf2fc832a8e534865d7c597fe