### PR TITLE
chore: remove stale mock hooks

### DIFF
--- a/frontend/src/components/IdentityInspector.jsx
+++ b/frontend/src/components/IdentityInspector.jsx
@@ -3,7 +3,6 @@
 
 import React, { useState, useEffect, useMemo } from 'react';
 import { useManifold } from '../context/ManifoldContext';
-import { useWebSocket } from '../context/WebSocketContext';
 import { 
   Search, 
   Eye, 
@@ -34,7 +33,6 @@ const IdentityInspector = () => {
     getDeterministicPath
   } = useManifold();
 
-  const { quantumSignals } = useWebSocket();
 
   const [searchTerm, setSearchTerm] = useState('');
   const [selectedKey, setSelectedKey] = useState('');

--- a/src/core/pattern_metric_engine.cpp
+++ b/src/core/pattern_metric_engine.cpp
@@ -329,8 +329,6 @@ namespace sep::quantum
             current_metrics_.push_back(m);
         }
 
-        // Cannot call generateSignals() from const method
-        // generateSignals();
         return current_metrics_;
     }
 


### PR DESCRIPTION
## Summary
- remove unused WebSocket hook from identity inspector
- drop commented generateSignals stub in PatternMetricEngine

## Testing
- `ctest` *(fails: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab253ea780832ab815e094d91ece53