### PR TITLE
Remove unused trading API placeholders

### DIFF
--- a/docs/00_SEP_PROFESSIONAL_SYSTEM_OVERVIEW.md
+++ b/docs/00_SEP_PROFESSIONAL_SYSTEM_OVERVIEW.md
@@ -52,7 +52,6 @@ The system implements a **three-tier professional architecture**:
 - **Port**: 5000
 - **Endpoints**: 
   - `/api/status` - System status and metrics
-  - `/api/trading/*` - Trading operations and management
   - `/api/performance/*` - Performance analytics
   - `/api/config/*` - Configuration management
   - `/api/health` - Health check endpoint

--- a/docs/01_DEPLOYMENT_INTEGRATION_GUIDE.md
+++ b/docs/01_DEPLOYMENT_INTEGRATION_GUIDE.md
@@ -349,13 +349,7 @@ GET  /api/health          # Health check
 GET  /api/status          # System status
 GET  /api/system/info     # System information
 
-# Trading operations
-GET  /api/trading/status       # Trading status
-POST /api/trading/start        # Start trading
-POST /api/trading/stop         # Stop trading
-POST /api/trading/positions    # Position management
-
-# Performance analytics  
+# Performance analytics
 GET  /api/performance/metrics     # Performance metrics
 GET  /api/performance/current    # Current performance
 GET  /api/performance/history    # Historical performance

--- a/docs/02_WEB_INTERFACE_ARCHITECTURE.md
+++ b/docs/02_WEB_INTERFACE_ARCHITECTURE.md
@@ -94,36 +94,6 @@ Response: {
 }
 ```
 
-##### Trading Operations
-```typescript
-// Trading status and control
-GET  /api/trading/status
-Response: {
-  is_trading: boolean,
-  current_position: Position | null,
-  last_signal: TradingSignal | null,
-  session_stats: SessionStats
-}
-
-POST /api/trading/start
-Body: { strategy?: string, parameters?: object }
-Response: { success: boolean, message: string }
-
-POST /api/trading/stop  
-Response: { success: boolean, message: string }
-
-GET  /api/trading/positions
-Response: {
-  open_positions: Position[],
-  closed_positions: Position[],
-  total_value: number
-}
-
-POST /api/trading/position/close
-Body: { position_id: string }
-Response: { success: boolean, position: Position }
-```
-
 ##### Performance Analytics
 ```typescript
 // Performance metrics and analytics

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -124,27 +124,6 @@ class APIClient {
     });
   }
 
-  async getPositions() {
-    return this.request('/api/positions');
-  }
-
-  async getTradingSignals() {
-    return this.request('/api/trading-signals');
-  }
-
-  // Quick Actions
-  async startTrading() {
-    return this.request('/api/trading/start', { method: 'POST' });
-  }
-
-  async stopTrading() {
-    return this.request('/api/trading/stop', { method: 'POST' });
-  }
-
-  async pauseSystem() {
-    return this.request('/api/system/pause', { method: 'POST' });
-  }
-
   async uploadTrainingData(payload = {}) {
     return this.request('/api/training/upload', {
       method: 'POST',
@@ -242,14 +221,9 @@ export const {
   fetchCandleData,
   getStoredCandles,
   submitOrder,
-  getPositions,
-  getTradingSignals,
   getSystemStatus,
   getSystemStatusConfig,
   getHealth,
-  startTrading,
-  stopTrading,
-  pauseSystem,
   uploadTrainingData,
   startModelTraining,
   generateReport,


### PR DESCRIPTION
## Summary
- drop unimplemented trading endpoints from API client
- remove references to `/api/trading/*` from system documentation

## Testing
- `CI=true npm test --silent -- --watchAll=false --passWithNoTests`
- `ctest`
- `npx eslint src/services/api.ts`


------
https://chatgpt.com/codex/tasks/task_e_68ab266b2350832a9fb1f3000f9e4865