### PR TITLE
Clean up duplicate report and remove unused frontend style

### DIFF
--- a/duplicate_implementations_report.md
+++ b/duplicate_implementations_report.md
@@ -53,15 +53,8 @@ This document tracks outstanding code quality concerns in the SEP Engine codebas
 - Obsolete weekly cache manager and data fetcher removed (`src/core/weekly_cache_manager.hpp`, `src/core/weekly_data_fetcher.*`, `config/training_config.json`).
 - Unimplemented WeeklyDataFetcher configuration and cache helpers removed (`src/core/weekly_data_fetcher.*`).
 - Removed redundant amplitude renormalization and stale CUDA stub reference (`src/app/QuantumProcessingService.cpp`, `src/core/cuda_impl.h`).
-<<<<<<< .merge_file_WVQ54O
-- Removed redundant amplitude renormalization and stale CUDA stub reference
-  (`src/app/QuantumProcessingService.cpp`, `src/core/cuda_impl.h`).
-- Redundant Valkey metric fallback helper removed (`src/util/interpreter.cpp`).
-- Unused prototype market data fetcher removed (`src/app/quantum_signal_bridge.cpp`).
 - Deprecated pattern analysis path removed; DSL builtins `measure_coherence`, `measure_stability`, and `measure_entropy` eliminated (`src/core/facade.*`, `src/util/interpreter.cpp`, docs).
-=======
 - Removed obsolete DSL memory declaration structure (`src/util/nodes.h`).
->>>>>>> .merge_file_WKAUTp
 
 ## Recommendations
 1. Remove remaining hardcoded values via configuration.

--- a/frontend/src/styles/App.css
+++ b/frontend/src/styles/App.css
@@ -713,30 +713,6 @@ html {
   font-size: 1rem;
   font-weight: 500;
 }
-/* Simplified Layout Styles */
-.simple-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 1rem 2rem;
-  background: var(--bg-secondary);
-  border-bottom: 1px solid var(--border);
-}
-
-.simple-header h1 {
-  font-size: 1.5rem;
-  font-weight: 600;
-  color: var(--primary);
-  margin: 0;
-}
-
-.connection-status {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  font-size: 0.875rem;
-  color: var(--text-secondary);
-}
 
 .status-dot {
   width: 8px;


### PR DESCRIPTION
## Summary
- Resolve merge conflict and consolidate cleanup history in `duplicate_implementations_report.md`
- Drop unused `.simple-header` CSS block and duplicate `connection-status` style

## Testing
- `ctest` *(skipped: documentation and style changes only)*

------
https://chatgpt.com/codex/tasks/task_e_68ab27ba3b70832a8f0bb9c09f9cba4d