### PR TITLE
docs: resolve duplicate report merge markers

### DIFF
--- a/duplicate_implementations_report.md
+++ b/duplicate_implementations_report.md
@@ -48,20 +48,12 @@ This document tracks outstanding code quality concerns in the SEP Engine codebas
 - Outdated Redis metrics API removed to reflect Valkey-only integration (`frontend/src/services/api.ts`).
 - Unused QuantumProcessingService and duplicate service-layer types removed (`src/app/QuantumProcessingService.*`, `src/app/QuantumTypes.h`, `src/app/PatternTypes.h`, `tests/app/quantum_processing_service_guard_test.cpp`).
 - Trade update handler now stores recent updates instead of logging to console (`frontend/src/context/WebSocketContext.js`).
-- Redundant Valkey metric fallback helper removed (`src/util/interpreter.cpp`).
 - Unused prototype market data fetcher removed (`src/app/quantum_signal_bridge.cpp`).
 - Obsolete weekly cache manager and data fetcher removed (`src/core/weekly_cache_manager.hpp`, `src/core/weekly_data_fetcher.*`, `config/training_config.json`).
 - Unimplemented WeeklyDataFetcher configuration and cache helpers removed (`src/core/weekly_data_fetcher.*`).
 - Removed redundant amplitude renormalization and stale CUDA stub reference (`src/app/QuantumProcessingService.cpp`, `src/core/cuda_impl.h`).
-<<<<<<< .merge_file_WVQ54O
-- Removed redundant amplitude renormalization and stale CUDA stub reference
-  (`src/app/QuantumProcessingService.cpp`, `src/core/cuda_impl.h`).
-- Redundant Valkey metric fallback helper removed (`src/util/interpreter.cpp`).
-- Unused prototype market data fetcher removed (`src/app/quantum_signal_bridge.cpp`).
 - Deprecated pattern analysis path removed; DSL builtins `measure_coherence`, `measure_stability`, and `measure_entropy` eliminated (`src/core/facade.*`, `src/util/interpreter.cpp`, docs).
-=======
 - Removed obsolete DSL memory declaration structure (`src/util/nodes.h`).
->>>>>>> .merge_file_WKAUTp
 
 ## Recommendations
 1. Remove remaining hardcoded values via configuration.


### PR DESCRIPTION
## Summary
- clean up residual merge conflict markers in duplicate implementation report
- clarify recent cleanup items like obsolete DSL memory structures and CUDA stub references

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_e_68ab27ba3b70832a8f0bb9c09f9cba4d