### PR TITLE
Remove hardcoded instrument and unify symbol context

### DIFF
--- a/duplicate_implementations_report.md
+++ b/duplicate_implementations_report.md
@@ -51,16 +51,13 @@ This document tracks outstanding code quality concerns in the SEP Engine codebas
 - Obsolete weekly cache manager and data fetcher removed (`src/core/weekly_cache_manager.hpp`, `src/core/weekly_data_fetcher.*`, `config/training_config.json`).
 - Unimplemented WeeklyDataFetcher configuration and cache helpers removed (`src/core/weekly_data_fetcher.*`).
 - Removed redundant amplitude renormalization and stale CUDA stub reference (`src/app/QuantumProcessingService.cpp`, `src/core/cuda_impl.h`).
-<<<<<<< .merge_file_rJoCiq
-- Deprecated pattern analysis path removed; DSL builtins `measure_coherence`, `measure_stability`, and `measure_entropy` eliminated (`src/core/facade.*`, `src/util/interpreter.cpp`, docs).
-- Removed obsolete DSL memory declaration structure (`src/util/nodes.h`).
-=======
 - Redundant Valkey metric fallback helper removed (`src/util/interpreter.cpp`).
 - Unused prototype market data fetcher removed (`src/app/quantum_signal_bridge.cpp`).
 - Deprecated pattern analysis path removed; DSL builtins `measure_coherence`, `measure_stability`, and `measure_entropy` eliminated (`src/core/facade.*`, `src/util/interpreter.cpp`, docs).
 - Removed obsolete DSL memory declaration structure (`src/util/nodes.h`).
 - Unimplemented UnifiedDataManager and SepEngineApp removed (`src/core/unified_data_manager.*`, `src/app/sep_engine_app.*`).
->>>>>>> .merge_file_CbVglJ
+- Hardcoded instrument in market model cache replaced with dynamic parameter (`src/app/market_model_cache.*`).
+- OANDA candle chart now uses global symbol context instead of internal state (`frontend/src/components/OandaCandleChart.jsx`).
 
 ## Recommendations
 1. Remove remaining hardcoded values via configuration.

--- a/src/app/market_model_cache.cpp
+++ b/src/app/market_model_cache.cpp
@@ -85,7 +85,7 @@ bool MarketModelCache::ensureCacheForLastWeek(const std::string& instrument) {
     }
 
     std::cout << "[CACHE] ⚡ Processing " << raw_candles.size() << " candles through quantum pipeline..." << std::endl;
-    processAndCacheData(raw_candles, cache_key);
+    processAndCacheData(instrument, raw_candles, cache_key);
     return true;
 }
 
@@ -116,20 +116,22 @@ void MarketModelCache::processBatch(const std::string& instrument, const std::ve
     }
 }
 
-void MarketModelCache::processAndCacheData(const std::vector<Candle>& raw_candles, const std::string& cache_key) {
-    processBatch("EUR_USD", raw_candles);
+void MarketModelCache::processAndCacheData(const std::string& instrument,
+                                           const std::vector<Candle>& raw_candles,
+                                           const std::string& cache_key) {
+    processBatch(instrument, raw_candles);
     std::cout << "[CACHE] ✅ Processing complete. Generated " << processed_signals_.size() << " signals." << std::endl;
-    saveCacheToValkey(cache_key);
+    saveCacheToValkey(instrument, cache_key);
 }
 
-bool MarketModelCache::saveCacheToValkey(const std::string& cache_key) const {
+bool MarketModelCache::saveCacheToValkey(const std::string& instrument, const std::string& cache_key) const {
     if (!valkey_context_) {
         std::cerr << "[CACHE] ❌ No Valkey connection available for saving" << std::endl;
         return false;
     }
     
     nlohmann::json j;
-    j["metadata"]["instrument"] = "EUR_USD";
+    j["metadata"]["instrument"] = instrument;
     j["metadata"]["created_at"] = std::chrono::duration_cast<std::chrono::seconds>(
         std::chrono::system_clock::now().time_since_epoch()).count();
     j["metadata"]["signal_count"] = processed_signals_.size();

--- a/src/app/market_model_cache.hpp
+++ b/src/app/market_model_cache.hpp
@@ -27,8 +27,10 @@ public:
 
 private:
     bool loadCacheFromValkey(const std::string& cache_key);
-    bool saveCacheToValkey(const std::string& cache_key) const;
-    void processAndCacheData(const std::vector<Candle>& raw_candles, const std::string& cache_key);
+    bool saveCacheToValkey(const std::string& instrument, const std::string& cache_key) const;
+    void processAndCacheData(const std::string& instrument,
+                             const std::vector<Candle>& raw_candles,
+                             const std::string& cache_key);
     std::string getCacheKeyForLastWeek(const std::string& instrument) const;
     
     // Valkey connection management


### PR DESCRIPTION
## Summary
- Process and cache market data for the requested instrument instead of always using `EUR_USD`
- Tie OANDA candle chart to the shared symbol context, removing local instrument state
- Document recent cleanup items in duplicate implementations report

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_e_68ab28f7550c832aad47709b8783effe