### PR TITLE
Clean duplicate implementations report

### DIFF
--- a/duplicate_implementations_report.md
+++ b/duplicate_implementations_report.md
@@ -5,6 +5,8 @@ This document tracks outstanding code quality concerns in the SEP Engine codebas
 
 ## Code Quality Issues
 
+- No remaining mock or placeholder components detected in `src/` or `frontend/`.
+
 ## Recent Cleanup
 - Legacy DSL bytecode and primitive modules removed (`src/util/compiler.*`,
   `src/util/core_primitives.*`, `src/util/stdlib.*`, `src/util/time_series.*`).
@@ -51,19 +53,12 @@ This document tracks outstanding code quality concerns in the SEP Engine codebas
 - Obsolete weekly cache manager and data fetcher removed (`src/core/weekly_cache_manager.hpp`, `src/core/weekly_data_fetcher.*`, `config/training_config.json`).
 - Unimplemented WeeklyDataFetcher configuration and cache helpers removed (`src/core/weekly_data_fetcher.*`).
 - Removed redundant amplitude renormalization and stale CUDA stub reference (`src/app/QuantumProcessingService.cpp`, `src/core/cuda_impl.h`).
-<<<<<<< .merge_file_JEYVqw
-
 - Redundant Valkey metric fallback helper removed (`src/util/interpreter.cpp`).
 - Unused prototype market data fetcher removed (`src/app/quantum_signal_bridge.cpp`).
 - Deprecated pattern analysis path removed; DSL builtins `measure_coherence`, `measure_stability`, and `measure_entropy` eliminated (`src/core/facade.*`, `src/util/interpreter.cpp`, docs).
 - Removed obsolete DSL memory declaration structure (`src/util/nodes.h`).
 - Unimplemented UnifiedDataManager and SepEngineApp removed (`src/core/unified_data_manager.*`, `src/app/sep_engine_app.*`).
 - Unused QFH placeholder kernel removed (`src/cuda/kernels.cu`).
-=======
-- Deprecated pattern analysis path removed; DSL builtins `measure_coherence`, `measure_stability`, and `measure_entropy` eliminated (`src/core/facade.*`, `src/util/interpreter.cpp`, docs).
-- Removed obsolete DSL memory declaration structure (`src/util/nodes.h`).
-- Unimplemented UnifiedDataManager and SepEngineApp removed (`src/core/unified_data_manager.*`, `src/app/sep_engine_app.*`).
->>>>>>> .merge_file_z6oTeX
 
 ## Recommendations
 1. Remove remaining hardcoded values via configuration.


### PR DESCRIPTION
## Summary
- resolve merge conflict and consolidate cleanup bullets in duplicate_implementations_report.md
- note that src/ and frontend/ contain no remaining mock or placeholder components

## Testing
- ⚠️ `ctest` *(skipped: documentation-only change)*

------
https://chatgpt.com/codex/tasks/task_e_68ab2afdd044832a8be0e6d7385f77f8