### PR TITLE
docs: note latest mock-free scan

### DIFF
--- a/duplicate_implementations_report.md
+++ b/duplicate_implementations_report.md
@@ -5,7 +5,7 @@ This document tracks outstanding code quality concerns in the SEP Engine codebas
 
 ## Code Quality Issues
 
-- No remaining mock or placeholder components detected in `src/` or `frontend/`.
+- *2025-08-24:* Deep scan confirmed no mock or placeholder components remain in `src/` or `frontend/`.
 
 ## Recent Cleanup
 - Legacy DSL bytecode and primitive modules removed (`src/util/compiler.*`,


### PR DESCRIPTION
## Summary
- record that a full scan on 2025-08-24 found no mock or placeholder components in `src/` or `frontend/`

## Testing
- ⚠️ `ctest` *(not run: documentation-only changes)*

------
https://chatgpt.com/codex/tasks/task_e_68ab8e2695a0832a8aa41202833a513b