### PR TITLE
chore: prune unused config helpers

### DIFF
--- a/duplicate_implementations_report.md
+++ b/duplicate_implementations_report.md
@@ -67,6 +67,7 @@ This document tracks outstanding code quality concerns in the SEP Engine codebas
 - Leftover pattern analysis function removed from EngineFacade (`src/core/facade.cpp`).
 - Fixed misplaced validation helpers in OANDA connector (`src/io/oanda_connector.cpp`).
 - Resolved merge artifact that duplicated validation logic in OANDA connector (`src/io/oanda_connector.cpp`).
+- Unused configuration helper functions removed to eliminate dead code (`src/util/interpreter.cpp`).
 
 ## Recommendations
 1. Remove remaining hardcoded values via configuration.

--- a/src/util/interpreter.cpp
+++ b/src/util/interpreter.cpp
@@ -37,16 +37,6 @@ namespace {
         return str_value == "true" || str_value == "1";
     }
     
-    // Helper function to get configuration value as double from engine facade
-    double get_config_double(const std::string& param_name, double default_value = 0.0) {
-        std::string str_value = get_config_string(param_name, std::to_string(default_value));
-        try {
-            return std::stod(str_value);
-        } catch (...) {
-            return default_value;
-        }
-    }
-    
     // Helper function to check market session status using real-time data
     bool is_market_open() {
         try {
@@ -67,16 +57,6 @@ namespace {
             return true;
         } catch (...) {
             return true;  // Default to open if calculation fails
-        }
-    }
-    
-    // Helper function to get configuration value as int from engine facade
-    int get_config_int(const std::string& param_name, int default_value = 0) {
-        std::string str_value = get_config_string(param_name, std::to_string(default_value));
-        try {
-            return std::stoi(str_value);
-        } catch (...) {
-            return default_value;
         }
     }
     


### PR DESCRIPTION
## Summary
- remove unused `get_config_double` and `get_config_int` helpers from DSL interpreter
- log cleanup in duplicate implementation report

## Testing
- no tests run

------
https://chatgpt.com/codex/tasks/task_e_68ab8fe01e00832abe2fc2d458ae0ff0