### PR TITLE
chore: remove unused manifold selection state

### DIFF
--- a/duplicate_implementations_report.md
+++ b/duplicate_implementations_report.md
@@ -62,6 +62,9 @@ This document tracks outstanding code quality concerns in the SEP Engine codebas
 - Removed unused PatternEvolutionTrainer and orphan CUDA walk-forward validator (`src/core/pattern_evolution_trainer.*`, `src/core/cuda_walk_forward_validator.*`).
 - Eliminated leftover PatternAnalysis implementation from EngineFacade to finalize deprecation (`src/core/facade.cpp`).
 - Added missing `<cstdint>` include for CUDA memory utilities (`src/cuda/memory.cu`).
+- Removed unused manifold selection state (`frontend/src/context/ManifoldContext.js`,
+  `frontend/src/components/IdentityInspector.jsx`,
+  `frontend/src/components/MetricTimeSeries.jsx`).
 
 - Obsolete OANDA trader entry point removed (`src/app/oanda_trader_main.cpp`, `src/CMakeLists.txt`).
 - Leftover pattern analysis function removed from EngineFacade (`src/core/facade.cpp`).

--- a/frontend/src/components/IdentityInspector.jsx
+++ b/frontend/src/components/IdentityInspector.jsx
@@ -25,8 +25,6 @@ const IdentityInspector = () => {
   const {
     processedIdentities,
     manifoldBands,
-    selectedIdentity,
-    setSelectedIdentity,
     getIdentityByKey,
     getIdentityHistory,
     canDeriveBackwards,

--- a/frontend/src/components/MetricTimeSeries.jsx
+++ b/frontend/src/components/MetricTimeSeries.jsx
@@ -36,9 +36,7 @@ const MetricTimeSeries = ({ metric = 'entropy', instrument = 'EUR_USD', timeWind
     processedIdentities,
     manifoldBands,
     ruptureEvents,
-    getIdentityHistory,
-    selectedIdentity,
-    setSelectedIdentity
+    getIdentityHistory
   } = useManifold();
 
   const { connected } = useWebSocket();

--- a/frontend/src/context/ManifoldContext.js
+++ b/frontend/src/context/ManifoldContext.js
@@ -15,7 +15,6 @@ export const ManifoldProvider = ({ children }) => {
 
   // Enhanced manifold state management
   const [ruptureEvents, setRuptureEvents] = useState([]);
-  const [selectedIdentity, setSelectedIdentity] = useState(null);
 
   // Process quantum signals into identity timelines
   const processedIdentities = useMemo(() => {
@@ -169,10 +168,6 @@ export const ManifoldProvider = ({ children }) => {
     manifoldBands,
     ruptureEvents,
 
-    // Selection state
-    selectedIdentity,
-    setSelectedIdentity,
-    
     // Helper functions
     getIdentityHistory,
     getIdentityByKey,


### PR DESCRIPTION
## Summary
- drop unused manifold selection state from context
- remove dead manifold props from IdentityInspector and MetricTimeSeries
- document manifold selection cleanup

## Testing
- `ctest` *(fails: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab8fe01e00832abe2fc2d458ae0ff0