### PR TITLE
Require explicit droplet configuration

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -55,7 +55,7 @@ export LD_LIBRARY_PATH=./build/src/core:./build/src/config:./build/src/c_api
 ./scripts/deploy_to_droplet.sh
 
 # SSH to droplet and configure
-ssh root@129.212.145.195
+ssh root@$DROPLET_IP
 cd /opt/sep-trader/sep-trader
 nano ../config/OANDA.env  # Add your OANDA credentials
 
@@ -63,7 +63,7 @@ nano ../config/OANDA.env  # Add your OANDA credentials
 docker-compose up -d
 
 # Verify deployment
-curl http://129.212.145.195/health
+curl http://$DROPLET_IP/health
 ```
 
 ## Build System
@@ -125,7 +125,7 @@ ls output/
 ### **3. Remote Trading Execution**
 ```bash
 # SSH to droplet
-ssh root@129.212.145.195
+ssh root@$DROPLET_IP
 
 # Check trading service status
 curl http://localhost:8080/api/status
@@ -195,7 +195,7 @@ docker-compose logs -f sep-trader
 3. Verify library path: `export LD_LIBRARY_PATH=./build/src/core:./build/src/config:./build/src/c_api`
 
 ### **Droplet Connectivity**
-1. Test SSH: `ssh root@129.212.145.195`
+1. Test SSH: `ssh root@$DROPLET_IP`
 2. Check services: `docker-compose ps`
 3. View logs: `docker-compose logs -f`
 

--- a/SYSTEM_STATUS_REPORT.md
+++ b/SYSTEM_STATUS_REPORT.md
@@ -108,7 +108,7 @@ Damping - lambda: 0.436532, V_i: 0.0131728
 #### **Remote Connection Verification**
 ```bash
 🌐 Configuring remote trader connection...
-Remote IP: 129.212.145.195
+Remote IP: <your-droplet-ip>
 [2025-08-20 04:42:39.569] [info] Remote trader connection configured
 ```
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -13,7 +13,7 @@ BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
 # Configuration
-DROPLET_IP="129.212.145.195"
+: "${DROPLET_IP:?DROPLET_IP not set}"
 DROPLET_USER="root"
 PROJECT_NAME="sep-trading"
 LOCAL_COMPOSE_FILE="docker-compose.production.yml"

--- a/docs/01_DEPLOYMENT_INTEGRATION_GUIDE.md
+++ b/docs/01_DEPLOYMENT_INTEGRATION_GUIDE.md
@@ -178,7 +178,7 @@ The complete droplet deployment process is automated through `deploy_to_droplet_
 
 ```bash
 # Configure droplet details
-export DROPLET_IP="129.212.145.195"
+export DROPLET_IP="<your-droplet-ip>"
 export DROPLET_USER="root"
 
 # Execute complete deployment
@@ -199,7 +199,7 @@ This script performs:
 #### Step 1: Droplet Preparation
 ```bash
 # SSH to droplet
-ssh root@129.212.145.195
+ssh root@$DROPLET_IP
 
 # System updates
 apt-get update && apt-get upgrade -y
@@ -263,9 +263,9 @@ docker-compose -f docker-compose.production.yml up -d
 #### Step 6: Production Validation
 ```bash
 # Service health checks
-curl -f http://129.212.145.195:5000/api/health
-curl -f http://129.212.145.195/health
-nc -z 129.212.145.195 8765
+curl -f http://$DROPLET_IP:5000/api/health
+curl -f http://$DROPLET_IP/health
+nc -z $DROPLET_IP 8765
 
 # Container status
 docker-compose -f docker-compose.production.yml ps
@@ -314,7 +314,7 @@ DATABASE_URL=postgresql://user:pass@localhost:5432/sep_trading
 
 # API configuration
 API_KEY_HEADER=X-SEP-API-KEY
-CORS_ORIGINS=http://localhost,http://129.212.145.195
+CORS_ORIGINS=http://localhost,http://$DROPLET_IP
 ```
 
 #### Frontend Environment
@@ -325,8 +325,8 @@ REACT_APP_WS_URL=<websocket-url>
 REACT_APP_ENVIRONMENT=development
 
 # Production
-REACT_APP_API_URL=http://129.212.145.195:5000
-REACT_APP_WS_URL=ws://129.212.145.195:8765
+REACT_APP_API_URL=http://$DROPLET_IP:5000
+REACT_APP_WS_URL=ws://$DROPLET_IP:8765
 REACT_APP_ENVIRONMENT=production
 ```
 

--- a/docs/02_WEB_INTERFACE_ARCHITECTURE.md
+++ b/docs/02_WEB_INTERFACE_ARCHITECTURE.md
@@ -446,7 +446,7 @@ const CORS_CONFIG = {
   origins: [
     'http://localhost:3000',  // Development frontend
     'http://localhost',       // Production frontend  
-    'http://129.212.145.195', // Remote production
+    'http://<your-droplet-ip>', // Remote production
   ],
   methods: ['GET', 'POST', 'PUT', 'DELETE'],
   allowedHeaders: ['Content-Type'],

--- a/docs/docs_archive/QUICKSTART.md
+++ b/docs/docs_archive/QUICKSTART.md
@@ -41,7 +41,7 @@ cd sep-trader
 ### Step 2: Configure Remote Credentials
 ```bash
 # SSH to droplet
-ssh root@129.212.145.195
+ssh root@$DROPLET_IP
 
 # Configure OANDA credentials
 cd /opt/sep-trader
@@ -106,7 +106,7 @@ echo 'pattern test { print("Local system ready!") }' > test.sep
 ./scripts/sync_to_droplet.sh
 
 # 3. Monitor remote trading (SSH to droplet)
-ssh root@129.212.145.195
+ssh root@$DROPLET_IP
 cd /opt/sep-trader/sep-trader
 docker-compose logs -f sep-trader
 ```
@@ -114,15 +114,15 @@ docker-compose logs -f sep-trader
 ### System Monitoring
 ```bash
 # Check remote system health
-curl http://129.212.145.195/health
-curl http://129.212.145.195/api/status
+curl http://$DROPLET_IP/health
+curl http://$DROPLET_IP/api/status
 
 # View trading logs
-ssh root@129.212.145.195
+ssh root@$DROPLET_IP
 tail -f /opt/sep-trader/logs/trading_service.log
 
 # Monitor PostgreSQL
-ssh root@129.212.145.195
+ssh root@$DROPLET_IP
 sudo -u postgres psql sep_trading -c "SELECT count(*) FROM trades;"
 ```
 
@@ -195,8 +195,8 @@ curl -X POST http://localhost:8080/api/data/reload  # Reload configuration
 export LD_LIBRARY_PATH=./build/src/core:./build/src/config:./build/src/c_api
 
 # Droplet connection problems
-ssh-keygen -R 129.212.145.195  # Remove old host key
-ssh root@129.212.145.195
+ssh-keygen -R $DROPLET_IP  # Remove old host key
+ssh root@$DROPLET_IP
 
 # Docker service issues
 docker-compose down && docker-compose up -d
@@ -208,7 +208,7 @@ docker-compose down && docker-compose up -d
 ./build/src/cli/trader-cli status
 
 # Remote system health
-curl http://129.212.145.195/health
+cURL http://$DROPLET_IP/health
 
 # End-to-end workflow test
 ./scripts/sync_to_droplet.sh

--- a/frontend/env.sh
+++ b/frontend/env.sh
@@ -3,10 +3,10 @@
 # Environment variables injection script for React frontend
 # This script runs at container startup to inject runtime environment variables
 
-# Set default values if not provided
-REACT_APP_API_URL=${REACT_APP_API_URL:-"http://129.212.145.195:5000"}
-REACT_APP_WS_URL=${REACT_APP_WS_URL:-"ws://129.212.145.195:8765"}
-REACT_APP_ENVIRONMENT=${REACT_APP_ENVIRONMENT:-"production"}
+# Require explicit environment variables
+: "${REACT_APP_API_URL:?REACT_APP_API_URL not set}"
+: "${REACT_APP_WS_URL:?REACT_APP_WS_URL not set}"
+: "${REACT_APP_ENVIRONMENT:?REACT_APP_ENVIRONMENT not set}"
 
 # Create env-config.js file with runtime environment variables
 cat <<EOF > /usr/share/nginx/html/env-config.js

--- a/pitch/PROJECT_MILESTONES.md
+++ b/pitch/PROJECT_MILESTONES.md
@@ -57,7 +57,7 @@
 - [x] **Production-Ready Build** - ✅ Clean build system with dynamic libraries
 
 ### 🌐 Phase 2: Cloud Deployment (Priority Focus)  
-- [ ] **Digital Ocean Setup** - Droplet configuration and security (129.212.145.195)
+- [ ] **Digital Ocean Setup** - Droplet configuration and security (<your-droplet-ip>)
 - [ ] **Tailscale Integration** - Private network access (100.85.55.105)  
 - [ ] **Data Synchronization** - Local PC → Droplet pipeline
 - [ ] **Lightweight Trading Service** - CPU-only execution on droplet


### PR DESCRIPTION
## Summary
- remove hardcoded droplet IP from deployment and frontend scripts
- document droplet usage via environment variables instead of fixed addresses

## Testing
- `ctest` *(fails: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab918c12d8832a83a9c91b815c3462