### PR TITLE
chore: remove unused trade updates context

### DIFF
--- a/duplicate_implementations_report.md
+++ b/duplicate_implementations_report.md
@@ -53,7 +53,6 @@ This document tracks outstanding code quality concerns in the SEP Engine codebas
 - Obsolete RemoteDataManager implementation and TrainingCoordinator stub removed (`src/core/RemoteDataManager.h`, `src/core/remote_data_manager.cpp`, `src/core/TrainingCoordinator.h`).
 - Outdated Redis metrics API removed to reflect Valkey-only integration (`frontend/src/services/api.ts`).
 - Unused QuantumProcessingService and duplicate service-layer types removed (`src/app/QuantumProcessingService.*`, `src/app/QuantumTypes.h`, `src/app/PatternTypes.h`, `tests/app/quantum_processing_service_guard_test.cpp`).
-- Trade update handler now stores recent updates instead of logging to console (`frontend/src/context/WebSocketContext.js`).
 - Obsolete weekly cache manager and data fetcher removed (`src/core/weekly_cache_manager.hpp`, `src/core/weekly_data_fetcher.*`, `config/training_config.json`).
 - Unimplemented WeeklyDataFetcher configuration and cache helpers removed (`src/core/weekly_data_fetcher.*`).
 - Removed redundant amplitude renormalization and stale CUDA stub reference (`src/app/QuantumProcessingService.cpp`, `src/core/cuda_impl.h`).
@@ -66,9 +65,6 @@ This document tracks outstanding code quality concerns in the SEP Engine codebas
 - Removed unused PatternEvolutionTrainer and orphan CUDA walk-forward validator (`src/core/pattern_evolution_trainer.*`, `src/core/cuda_walk_forward_validator.*`).
 - Eliminated leftover PatternAnalysis implementation from EngineFacade to finalize deprecation (`src/core/facade.cpp`).
 - Added missing `<cstdint>` include for CUDA memory utilities (`src/cuda/memory.cu`).
-- Manifold selection components remain active and integrated with real-time data (`frontend/src/context/ManifoldContext.js`,
-  `frontend/src/components/IdentityInspector.jsx`,
-  `frontend/src/components/MetricTimeSeries.jsx`).
 - Obsolete OANDA trader entry point removed (`src/app/oanda_trader_main.cpp`, `src/CMakeLists.txt`).
 - Leftover pattern analysis function removed from EngineFacade (`src/core/facade.cpp`).
 - Fixed misplaced validation helpers in OANDA connector (`src/io/oanda_connector.cpp`).

--- a/frontend/src/context/WebSocketContext.js
+++ b/frontend/src/context/WebSocketContext.js
@@ -18,7 +18,6 @@ export const WebSocketProvider = ({ children }) => {
   const [marketData, setMarketData] = useState({});
   const [systemStatus, setSystemStatus] = useState({});
   const [tradingSignals, setTradingSignals] = useState([]);
-  const [tradeUpdates, setTradeUpdates] = useState([]);
   const [performanceData, setPerformanceData] = useState({});
   const [systemMetrics, setSystemMetrics] = useState({});
   
@@ -83,15 +82,6 @@ export const WebSocketProvider = ({ children }) => {
         ...data,
         lastUpdate: new Date().toISOString()
       }));
-    },
-    
-    trades: (data) => {
-      if (data) {
-        setTradeUpdates(prev => {
-          const updates = [data, ...prev];
-          return updates.slice(0, 100);
-        });
-      }
     },
     
     // New handlers for Valkey/Redis data streams
@@ -488,7 +478,6 @@ export const WebSocketProvider = ({ children }) => {
     tradingSignals,
     performanceData,
     systemMetrics,
-    tradeUpdates,
     
     // Valkey/Redis quantum data
     quantumSignals,
@@ -543,11 +532,6 @@ export const useSystemStatus = () => {
 export const usePerformanceData = () => {
   const { performanceData } = useWebSocket();
   return performanceData;
-};
-
-export const useTradeUpdates = () => {
-  const { tradeUpdates } = useWebSocket();
-  return tradeUpdates;
 };
 
 export { WebSocketContext };


### PR DESCRIPTION
## Summary
- drop unused trade update state from WebSocket context
- prune obsolete notes about trade updates and removed manifold UI components from duplicate report

## Testing
- `npm test -- --watchAll=false --passWithNoTests`
- `ctest` *(fails: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac2c138934832a8016c214c2ddf3b9