### PR TITLE
chore: remove unused websocket handlers

### DIFF
--- a/duplicate_implementations_report.md
+++ b/duplicate_implementations_report.md
@@ -66,15 +66,13 @@ This document tracks outstanding code quality concerns in the SEP Engine codebas
 - Removed unused PatternEvolutionTrainer and orphan CUDA walk-forward validator (`src/core/pattern_evolution_trainer.*`, `src/core/cuda_walk_forward_validator.*`).
 - Eliminated leftover PatternAnalysis implementation from EngineFacade to finalize deprecation (`src/core/facade.cpp`).
 - Added missing `<cstdint>` include for CUDA memory utilities (`src/cuda/memory.cu`).
-- Manifold selection components remain active and integrated with real-time data (`frontend/src/context/ManifoldContext.js`,
-  `frontend/src/components/IdentityInspector.jsx`,
-  `frontend/src/components/MetricTimeSeries.jsx`).
 - Obsolete OANDA trader entry point removed (`src/app/oanda_trader_main.cpp`, `src/CMakeLists.txt`).
 - Leftover pattern analysis function removed from EngineFacade (`src/core/facade.cpp`).
 - Fixed misplaced validation helpers in OANDA connector (`src/io/oanda_connector.cpp`).
 - Resolved merge artifact that duplicated validation logic in OANDA connector (`src/io/oanda_connector.cpp`).
 - Obsolete OANDA historical fetcher and script dependency removed (`oanda_historical_fetcher.cpp`, `run_trader.sh`).
 - Unused configuration helper functions removed to eliminate dead code (`src/util/interpreter.cpp`).
+- Pruned unused WebSocket data handlers and legacy socket.io client dependency, keeping only active real-time streams (`frontend/src/context/WebSocketContext.js`, `frontend/package.json`, `frontend/src/components/OandaCandleChart.jsx`).
 
 ## Recommendations
 1. Remove remaining hardcoded values via configuration.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,7 +19,6 @@
     "react-router-dom": "^6.3.0",
     "react-scripts": "^5.0.1",
     "recharts": "^2.7.2",
-    "socket.io-client": "^4.7.2",
     "styled-components": "^5.3.11",
     "tailwindcss": "^3.3.3",
     "underscore": "^1.13.6"
@@ -56,6 +55,5 @@
     "@types/styled-components": "^5.1.26",
     "eslint-config-react-app": "^7.0.1",
     "typescript": "^4.9.5"
-  },
-  "proxy": "http://localhost:8080"
+  }
 }

--- a/frontend/src/components/OandaCandleChart.jsx
+++ b/frontend/src/components/OandaCandleChart.jsx
@@ -27,7 +27,7 @@ const OandaCandleChart = ({ height = 400, showControls = true }) => {
   const [viewMode, setViewMode] = useState('line'); // 'line' or 'area'
   const [timeRange, setTimeRange] = useState('2weeks'); // '1week', '2weeks'
 
-  const { valkeyMetrics, connected } = useWebSocket();
+  const { connected } = useWebSocket();
   const { selectedSymbol, setSelectedSymbol, symbols } = useSymbol();
 
   // Fetch candle data from Valkey


### PR DESCRIPTION
## Summary
- prune unused market/system/trade state from WebSocket context
- drop socket.io client dependency and dev proxy
- clean OANDA chart component
- document websocket cleanup

## Testing
- `npm test -- --watchAll=false --passWithNoTests`
- `ctest` *(fails: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac2bdcd25c832a8fef96a1deb2d99e