### PR TITLE
feat(frontend): allow runtime api url

### DIFF
--- a/docs/02_WEB_INTERFACE_ARCHITECTURE.md
+++ b/docs/02_WEB_INTERFACE_ARCHITECTURE.md
@@ -61,7 +61,7 @@ frontend/
 
 #### Base Configuration
 ```typescript
-API Base URL: http://[host]:5000/api
+API Base URL: configured via `REACT_APP_API_URL` (e.g., http://[host]:5000/api)
 Content-Type: application/json
 Authentication: X-SEP-API-KEY header (for protected endpoints)
 CORS Policy: Configured for frontend origins

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,7 +1,9 @@
 // SEP Trading System - API Service
 // Simplified API client for core backend communications
 
-const API_BASE_URL = process.env.REACT_APP_API_URL;
+const API_BASE_URL =
+  process.env.REACT_APP_API_URL ||
+  (window as any)?._env_?.REACT_APP_API_URL;
 if (!API_BASE_URL) {
   throw new Error('REACT_APP_API_URL is not configured');
 }


### PR DESCRIPTION
## Summary
- allow runtime-injected API URL in frontend client
- document API URL environment variable for web interface

## Testing
- `ctest` *(fails: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac2dbedb04832aad8d13eae8156c00