### PR TITLE
feat: support authenticated valkey connections

### DIFF
--- a/scripts/seed_valkey.py
+++ b/scripts/seed_valkey.py
@@ -6,7 +6,9 @@ from oanda_connector import OandaConnector
 from datetime import datetime
 
 # Use your remote Valkey URL with credentials
-VALKEY_URL = os.getenv("VALKEY_URL", "redis://localhost:6379/0")
+VALKEY_URL = os.getenv("VALKEY_URL")
+if not VALKEY_URL:
+    raise EnvironmentError("VALKEY_URL environment variable is required")
 INSTRUMENT = "EUR_USD"
 
 def fetch_candles_from_oanda():


### PR DESCRIPTION
## Summary
- parse VALKEY_URL with optional password and database for MarketModelCache
- require VALKEY_URL environment variable in seed_valkey utility

## Testing
- `python -m py_compile scripts/seed_valkey.py`
- `cmake -S . -B build -GNinja -DSEP_USE_CUDA=OFF -DBUILD_TESTING=ON` *(fails: Cannot find source file: filter_test.cpp)*

------
https://chatgpt.com/codex/tasks/task_e_68ac3259d194832a89f0a6de8fbe488a