### PR TITLE
docs: record T1 beta sweep

### DIFF
--- a/whitepaper/SEP_Research_Next_Steps.md
+++ b/whitepaper/SEP_Research_Next_Steps.md
@@ -4,6 +4,13 @@
 **Priority:** HIGH - Critical Issues Identified  
 **Context:** T4 running >56 minutes, 4/5 tests failing validation
 
+## ✅ Progress Update (August 25, 2025)
+
+- Ran T1 beta sweep (β ∈ {0.01, 0.05, 0.1, 0.2})
+  - Best RMSE: 0.0959 at β=0.01 (threshold 0.05)
+  - Reactive ratio: 0.471 (threshold 2.0)
+- **Conclusion**: Beta tuning alone insufficient—scale-invariance remains time-base sensitive
+
 ## 🚨 Immediate Actions Required (Today)
 
 ### 1. T4 Process Management
@@ -16,9 +23,9 @@
 Priority order based on impact:
 
 #### T1 (Time Scaling) - CRITICAL
-- **Issue**: RMSE 0.174 >> 0.05 threshold (348% over limit)
-- **Root Cause**: [`bit_mapping_D1()`](whitepaper/validation/sep_core.py:56) sensitivity to signal characteristics
-- **Next Step**: Test with different beta values (0.01, 0.05, 0.2)
+- **Issue**: Best RMSE 0.0959 > 0.05 and ratio 0.471 < 2.0 despite beta sweep
+- **Root Cause**: [`mapping_D2_dilation_robust`](whitepaper/validation/test_scripts/T1_time_scaling_test.py) and EMA remain tied to sample indices
+- **Next Step**: Anchor β to physical time or redesign D2 mapping to remove time-base sensitivity
 
 #### T3 (Convolution Invariance) - CRITICAL  
 - **Issue**: RMSE 0.188 >> 0.05 threshold (376% over limit)
@@ -48,6 +55,7 @@ for beta in [0.01, 0.05, 0.1, 0.2]:
     # Run with modified beta
 "
 ```
+# Result: best β=0.01 → RMSE 0.0959, ratio 0.471 (still failing)
 
 ### Week of August 25-31
 

--- a/whitepaper/SEP_Validation_Research_Analysis.md
+++ b/whitepaper/SEP_Validation_Research_Analysis.md
@@ -15,10 +15,11 @@ The consolidated whitepaper validation research reveals a comprehensive testing 
 - **Entropy Reduction**: 36.3% reduction > 10% threshold  
 - **Key Finding**: Market data shows SEP invariance properties  
 
-### ❌ FAILED: T1 - Time Scaling  
-- **H1 (Isolated Invariance)**: RMSE 0.174 > 0.05 threshold  
-- **H2 (Reactive Sensitivity)**: Ratio 0.357 < 2.0 threshold  
-- **Issue**: Neither isolated nor reactive processes show expected scaling behavior  
+### ❌ FAILED: T1 - Time Scaling
+- **H1 (Isolated Invariance)**: Best RMSE 0.0959 > 0.05 threshold (β=0.01)
+- **H2 (Reactive Sensitivity)**: Best ratio 0.471 < 2.0 threshold (β=0.01)
+- **Parameter Sweep**: β ∈ {0.01, 0.05, 0.1, 0.2} → no configuration met thresholds
+- **Issue**: Neither isolated nor reactive processes show expected scaling behavior
 
 ### ❌ FAILED: T2 - Maximum Entropy  
 - **H3 (Pairwise Sufficiency)**: 12.2% < 30% threshold  

--- a/whitepaper/whitepaper.md
+++ b/whitepaper/whitepaper.md
@@ -80,9 +80,10 @@ This infrastructure successfully enabled the detection of critical implementatio
 - Test both D1 (negative control) and D2 (target) mappings
 
 **Results**:
-- **D2 Mapping (Target)**: Median RMSE = 0.089 > 0.05 threshold → **FAIL**
-- **D1 Mapping (Control)**: Median RMSE = 0.152 > 0.05 threshold → Expected failure ✓
+- **D2 Mapping (Target)**: Median RMSE = 0.0959 > 0.05 threshold → **FAIL**
+- **D1 Mapping (Control)**: Median RMSE = 0.1049 > 0.05 threshold → Expected failure ✓
 - **Trend Analysis**: RMSE increases with γ, indicating systematic time-base sensitivity
+- **β Sweep (Aug 25, 2025)**: Best reactive/isolated ratio = 0.471 at β=0.01 (threshold 2.0)
 
 ![T1 Results](validation/test_scripts/validation/results/T1/T1_plots.png)
 


### PR DESCRIPTION
## Summary
- document beta sweep results for T1 time-scaling test
- capture parameter sweep outcome in research next steps
- update whitepaper with latest T1 metrics and beta-sensitivity note

## Testing
- `python whitepaper/validation/test_scripts/T1_time_scaling_test.py --beta 0.01`
- `python whitepaper/validation/test_scripts/T1_time_scaling_test.py --beta 0.05`
- `python whitepaper/validation/test_scripts/T1_time_scaling_test.py --beta 0.1`
- `python whitepaper/validation/test_scripts/T1_time_scaling_test.py --beta 0.2`


------
https://chatgpt.com/codex/tasks/task_e_68ac3915d304832a81b2b943efe7be07