### PR TITLE
Fix validation harness and document baseline results

### DIFF
--- a/whitepaper/SEP_Research_Next_Steps.md
+++ b/whitepaper/SEP_Research_Next_Steps.md
@@ -4,6 +4,15 @@
 **Priority:** HIGH - Critical Issues Identified  
 **Context:** T4 running >56 minutes, 4/5 tests failing validation
 
+### Latest Progress (10:30 UTC)
+- Installed missing Python dependencies (`scipy`, `matplotlib`, `scikit-learn`, `seaborn`) enabling execution of validation scripts.
+- Fixed `T3_convolutional_invariance_test.py` import and formatting errors.
+- Updated `run_fast_validation.py` to correctly import test modules and create nested result directories.
+- Ran fast validation: 
+  - **T1** – H1 RMSE `0.0786` (>0.05) → **FAIL**.
+  - **T2** – H3 reduction `0.093` (<0.30) **FAIL**, H4 excess `0.0402` (<0.05) **PASS**; runtime ~121s.
+- Execution halted during T3; profiling and timeout support still required.
+
 ## 🚨 Immediate Actions Required (Today)
 
 ### 1. T4 Process Management
@@ -47,6 +56,13 @@ for beta in [0.01, 0.05, 0.1, 0.2]:
     print(f'Testing beta={beta}')
     # Run with modified beta
 "
+```
+
+```bash
+# 4. Collect baseline fast-validation results
+cd whitepaper/validation && python run_fast_validation.py
+#   - T1 RMSE 0.0786 (FAIL)
+#   - T2 reduction 0.093 (FAIL), H4 excess 0.0402 (PASS)
 ```
 
 ### Week of August 25-31

--- a/whitepaper/validation/run_fast_validation.py
+++ b/whitepaper/validation/run_fast_validation.py
@@ -79,11 +79,12 @@ def run_test(test_module, results_dir):
     
     try:
         # Import and run the test
-        module = __import__(test_module.replace('.py', ''))
+        module_name = test_module.replace('.py', '').replace('/', '.')
+        module = __import__(module_name, fromlist=[''])
         
         # Redirect results to our timestamped directory
         test_results_path = results_dir / test_name
-        test_results_path.mkdir(exist_ok=True)
+        test_results_path.mkdir(parents=True, exist_ok=True)
         
         # Change working directory to put results in the right place
         original_cwd = os.getcwd()

--- a/whitepaper/validation/test_scripts/T3_convolutional_invariance_test.py
+++ b/whitepaper/validation/test_scripts/T3_convolutional_invariance_test.py
@@ -3,6 +3,7 @@
 import argparse
 import json
 import csv
+import os
 
 import numpy as np
 from scipy.signal import firwin, lfilter
@@ -108,7 +109,7 @@ def main() -> None:
 
     print("============================================================")
     print("Running Test T3: Convolutional Invariance")
-    print("===================================
+    print("============================================================")
 
     x = generate_chirp(length=200000, f0=10, f1=50, snr_db=20)
 


### PR DESCRIPTION
## Summary
- import missing modules and repair header banner in T3 convolutional invariance test
- make fast validation runner resolve modules correctly and handle nested results paths
- record baseline fast-validation metrics and outstanding tasks in research notes

## Testing
- `python run_fast_validation.py` (fails: execution halted during T3)

------
https://chatgpt.com/codex/tasks/task_e_68ac3915d304832a81b2b943efe7be07