### PR TITLE
fix: quote NVCC noexcept flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,7 +119,7 @@ if(SEP_USE_CUDA)
     # Core compiler flags + Fedora 42 glibc 2.41 -> Ubuntu 24.04 glibc 2.39 compatibility
     set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --expt-relaxed-constexpr --extended-lambda -Xcompiler -fno-strict-aliasing -Xcompiler -Wno-deprecated-declarations -Xcompiler -Wno-deprecated-copy -Xcompiler -D_FORCE_INLINES -Xcompiler -w")
     # TARGETED FIX: Resolve ABI impedance mismatch between CUDA 12.9 and glibc 2.41 (noexcept specification divergence)
-    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcompiler -Dnoexcept\\\\(x\\\\)=")
+    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcompiler=-Dnoexcept\\\\(x\\\\)=")
     # NUCLEAR OPTION: Block glibc math headers entirely for CUDA compilation
     set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcompiler -D__MATH_H=1")
     set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcompiler -D_MATH_H=1")

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,5 +1,7 @@
 Below is a **structured execution plan** for building a suite of visual aids to accompany the SEP Engine whitepaper.  The plan is grounded in an investigation of the **`SepDynamics/sep‑trader` repo**—particularly the `frontend/`, `docs/`, and `src/` folders—and is designed to explain SEP’s concepts to a **high‑school‑level audience**.  Each task references the relevant code and documentation lines for context.
 
+**Build Maintenance:** Quoted the `-Dnoexcept(x)=` CUDA flag in `CMakeLists.txt` to resolve NVCC parsing errors.
+
 ---
 
 ## 1. Groundwork: Understand the Existing Code and Metrics


### PR DESCRIPTION
## Summary
- quote `-Dnoexcept(x)=` flag when passing to NVCC to avoid parse errors
- document build flag fix in docs/TODO.md

## Testing
- `./build.sh` *(fails: The CMAKE_CXX_COMPILER: /usr/bin/g++-11 is not a full path to an existing compiler tool)*
- `cd build && ctest` *(fails: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac38f548c8832a95703052894dc036