### PR TITLE
Fix NVCC flag handling and refresh build docs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,7 +119,8 @@ if(SEP_USE_CUDA)
     # Core compiler flags + Fedora 42 glibc 2.41 -> Ubuntu 24.04 glibc 2.39 compatibility
     set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --expt-relaxed-constexpr --extended-lambda -Xcompiler -fno-strict-aliasing -Xcompiler -Wno-deprecated-declarations -Xcompiler -Wno-deprecated-copy -Xcompiler -D_FORCE_INLINES -Xcompiler -w")
     # TARGETED FIX: Resolve ABI impedance mismatch between CUDA 12.9 and glibc 2.41 (noexcept specification divergence)
-    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcompiler -Dnoexcept\\\\(x\\\\)=")
+    # Use '=' form to keep the full macro definition a single argument for nvcc
+    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcompiler=-Dnoexcept(x)=")
     # NUCLEAR OPTION: Block glibc math headers entirely for CUDA compilation
     set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcompiler -D__MATH_H=1")
     set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcompiler -D_MATH_H=1")

--- a/docs/00_Project_Overview.md
+++ b/docs/00_Project_Overview.md
@@ -39,9 +39,9 @@ This separation ensures both high performance for model training and cost-effect
     ```
 2.  **Install Dependencies & Build:**
     ```bash
-    # Use --no-docker for a local build on a machine with CUDA
-    ./install.sh --minimal --no-docker
-    ./build.sh --no-docker
+    # Build using Docker (required for CUDA)
+    ./install.sh --minimal
+    ./build.sh
     ```
 3.  **Set Library Path:**
     ```bash

--- a/docs/00_SEP_PROFESSIONAL_SYSTEM_OVERVIEW.md
+++ b/docs/00_SEP_PROFESSIONAL_SYSTEM_OVERVIEW.md
@@ -119,8 +119,8 @@ git clone [repository-url]
 cd sep-trader
 
 # Build core components
-./install.sh --minimal --no-docker  # verifies NVCC and adds it to PATH
-./build.sh --no-docker
+./install.sh --minimal  # verifies NVCC and adds it to PATH
+./build.sh
 
 # Deploy containerized services
 ./deploy.sh start

--- a/docs/01_DEPLOYMENT_INTEGRATION_GUIDE.md
+++ b/docs/01_DEPLOYMENT_INTEGRATION_GUIDE.md
@@ -76,8 +76,8 @@ git clone [repository-url]
 cd sep-trader
 
 # 2. Core System Build
-./install.sh --minimal --no-docker
-./build.sh --no-docker
+./install.sh --minimal
+./build.sh
 
 # 3. Environment Configuration
 cp config/.sep-config.env.template .sep-config.env
@@ -156,7 +156,7 @@ npm run dev  # Runs on port 3000 with hot reload
 docker-compose restart trading-backend
 
 # Core engine development (rebuild required)
-./build.sh --no-docker
+./build.sh
 docker-compose restart trading-backend
 ```
 

--- a/docs/04_Development_Guide.md
+++ b/docs/04_Development_Guide.md
@@ -14,7 +14,7 @@ The project uses a unified build system for both Linux and Windows, orchestrated
 
 ### Building the Project
 
-*   **Linux:** `./build.sh --no-docker` (for local CUDA build)
+*   **Linux:** `./build.sh` (Docker-based CUDA build)
 *   **Windows:** `.\build.bat` (uses Docker)
 
 ## 2. 💻 CUDA Development

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,5 +1,7 @@
 Below is a **structured execution plan** for building a suite of visual aids to accompany the SEP Engine whitepaper.  The plan is grounded in an investigation of the **`SepDynamics/sep‑trader` repo**—particularly the `frontend/`, `docs/`, and `src/` folders—and is designed to explain SEP’s concepts to a **high‑school‑level audience**.  Each task references the relevant code and documentation lines for context.
 
+- [x] Quote `-Dnoexcept(x)=` in CMake for stable NVCC builds; default all build scripts to Docker for CUDA.
+
 ---
 
 ## 1. Groundwork: Understand the Existing Code and Metrics


### PR DESCRIPTION
## Summary
- quote `-Dnoexcept(x)=` when passing to nvcc to keep macro as single argument
- remove `--no-docker` references across docs and guide developers to Docker-based CUDA builds
- note build-system update in docs/TODO

## Testing
- `./build.sh` *(fails: CUDA toolkit not detected, build configured without CUDA and compilation interrupted at 39/202 objects)*

------
https://chatgpt.com/codex/tasks/task_e_68ac38f548c8832a95703052894dc036